### PR TITLE
Add more integ tests, add some unit tests, add Jacoco for test coverage reporting

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,8 @@ Integration tests are included. To test them, certain environment variables need
 
 * `AWS_S3EC_TEST_BUCKET` - The bucket to write test values to
 * `AWS_S3EC_TEST_KMS_KEY_ID` - The key id for the KMS key used for KMS tests
-* `AWS_S3EC_TEST_KMS_REGION` - The region the KMS key resides e.g. us-east-1`
+* `AWS_S3EC_TEST_KMS_KEY_ALIAS` - An alias for the KMS key used for KMS tests. The alias must reference the key ID above. 
+* `AWS_REGION` - The region the AWS resources (KMS key, S3 bucket) resides e.g. "us-east-1"
 
 ## Migration
 

--- a/pom.xml
+++ b/pom.xml
@@ -108,7 +108,35 @@
         <artifactId>maven-surefire-plugin</artifactId>
         <version>2.22.2</version>
       </plugin>
+
+      <plugin>
+        <groupId>org.jacoco</groupId>
+        <artifactId>jacoco-maven-plugin</artifactId>
+        <version>0.8.8</version>
+        <executions>
+          <execution>
+            <goals>
+              <goal>prepare-agent</goal>
+            </goals>
+          </execution>
+          <execution>
+            <id>report</id>
+            <phase>prepare-package</phase>
+            <goals>
+              <goal>report</goal>
+            </goals>
+          </execution>
+          <execution>
+            <id>check</id>
+            <goals>
+              <goal>check</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
   </build>
+
+
 
 </project>

--- a/src/main/java/software/amazon/encryption/s3/materials/AesKeyring.java
+++ b/src/main/java/software/amazon/encryption/s3/materials/AesKeyring.java
@@ -9,6 +9,7 @@ import java.util.Map;
 import javax.crypto.Cipher;
 import javax.crypto.SecretKey;
 import javax.crypto.spec.GCMParameterSpec;
+
 import software.amazon.encryption.s3.S3EncryptionClientException;
 import software.amazon.encryption.s3.algorithms.AlgorithmSuite;
 
@@ -169,7 +170,10 @@ public class AesKeyring extends S3Keyring {
             return this;
         }
 
-        public Builder wrappingKey(SecretKey wrappingKey) {
+        public Builder wrappingKey(final SecretKey wrappingKey) {
+            if (wrappingKey == null) {
+                throw new S3EncryptionClientException("Wrapping key cannot be null!");
+            }
             if (!wrappingKey.getAlgorithm().equals(KEY_ALGORITHM)) {
                 throw new S3EncryptionClientException("Invalid algorithm: " + wrappingKey.getAlgorithm() + ", expecting " + KEY_ALGORITHM);
             }

--- a/src/main/java/software/amazon/encryption/s3/materials/S3Keyring.java
+++ b/src/main/java/software/amazon/encryption/s3/materials/S3Keyring.java
@@ -113,12 +113,18 @@ abstract public class S3Keyring implements Keyring {
             return builder();
         }
 
-        public BuilderT secureRandom(SecureRandom secureRandom) {
+        public BuilderT secureRandom(final SecureRandom secureRandom) {
+            if (secureRandom == null) {
+                throw new S3EncryptionClientException("SecureRandom cannot be null!");
+            }
             _secureRandom = secureRandom;
             return builder();
         }
 
-        public BuilderT dataKeyGenerator(DataKeyGenerator dataKeyGenerator) {
+        public BuilderT dataKeyGenerator(final DataKeyGenerator dataKeyGenerator) {
+            if (dataKeyGenerator == null) {
+                throw new S3EncryptionClientException("DataKeyGenerator cannot be null!");
+            }
             _dataKeyGenerator = dataKeyGenerator;
             return builder();
         }

--- a/src/test/java/software/amazon/encryption/s3/S3EncryptionClientTest.java
+++ b/src/test/java/software/amazon/encryption/s3/S3EncryptionClientTest.java
@@ -1,0 +1,127 @@
+package software.amazon.encryption.s3;
+
+import org.junit.jupiter.api.Test;
+import software.amazon.awssdk.core.ResponseBytes;
+import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.GetObjectResponse;
+
+import javax.crypto.KeyGenerator;
+import javax.crypto.SecretKey;
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.security.NoSuchAlgorithmException;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static software.amazon.encryption.s3.S3EncryptionClient.withAdditionalEncryptionContext;
+
+/**
+ * This class is an integration test for verifying behavior of the V3 client
+ * under various scenarios.
+ */
+public class S3EncryptionClientTest {
+
+    private static final String BUCKET = System.getenv("AWS_S3EC_TEST_BUCKET");
+    private static final String KMS_KEY_ID = System.getenv("AWS_S3EC_TEST_KMS_KEY_ID");
+    // This alias must point to the same key as KMS_KEY_ID
+    private static final String KMS_KEY_ALIAS = System.getenv("AWS_S3EC_TEST_KMS_KEY_ALIAS");
+
+    @Test
+    public void KmsWithAliasARN() {
+        S3Client v3Client = S3EncryptionClient.builder()
+                .kmsKeyId(KMS_KEY_ALIAS)
+                .build();
+
+        simpleV3RoundTrip(v3Client);
+    }
+
+    @Test
+    public void KmsWithShortKeyId() {
+        // Just assume the ARN is well-formed
+        // Also assume that the region is set correctly
+        final String shortId = KMS_KEY_ID.split("/")[1];
+
+        S3Client v3Client = S3EncryptionClient.builder()
+                .kmsKeyId(shortId)
+                .build();
+
+        simpleV3RoundTrip(v3Client);
+    }
+
+    @Test
+    public void KmsAliasARNToKeyId() {
+        S3Client aliasClient = S3EncryptionClient.builder()
+                .kmsKeyId(KMS_KEY_ALIAS)
+                .build();
+
+        S3Client keyIdClient = S3EncryptionClient.builder()
+                .kmsKeyId(KMS_KEY_ID)
+                .build();
+
+        final String input = "KmsAliasARNToKeyId";
+        Map<String, String> encryptionContext = new HashMap<>();
+        encryptionContext.put("user-metadata-key", "user-metadata-value-alias-to-id");
+
+        aliasClient.putObject(builder -> builder
+                        .bucket(BUCKET)
+                        .key(input)
+                        .overrideConfiguration(withAdditionalEncryptionContext(encryptionContext)),
+                RequestBody.fromString(input));
+
+        ResponseBytes<GetObjectResponse> objectResponse = keyIdClient.getObjectAsBytes(builder -> builder
+                .bucket(BUCKET)
+                .key(input)
+                .overrideConfiguration(withAdditionalEncryptionContext(encryptionContext)));
+        String output = objectResponse.asUtf8String();
+        assertEquals(input, output);
+    }
+
+    @Test
+    public void AesKeyringWithInvalidAesKey() throws NoSuchAlgorithmException {
+        SecretKey invalidAesKey;
+        KeyGenerator keyGen = KeyGenerator.getInstance("DES");
+        keyGen.init(56);
+        invalidAesKey = keyGen.generateKey();
+
+        assertThrows(S3EncryptionClientException.class, () -> S3EncryptionClient.builder()
+                .aesKey(invalidAesKey)
+                .build());
+    }
+
+    @Test
+    public void RsaKeyringWithInvalidRsaKey() throws NoSuchAlgorithmException {
+        KeyPair invalidRsaKey;
+        KeyPairGenerator keyPairGen = KeyPairGenerator.getInstance("EC");
+        keyPairGen.initialize(256);
+        invalidRsaKey = keyPairGen.generateKeyPair();
+
+        assertThrows(S3EncryptionClientException.class, () -> S3EncryptionClient.builder()
+                .rsaKeyPair(invalidRsaKey)
+                .build());
+    }
+
+    /**
+     * A simple, reusable round-trip (encryption + decryption) using a given
+     * S3Client. Useful for testing client configuration.
+     * @param v3Client the client under test
+     */
+    private void simpleV3RoundTrip(final S3Client v3Client) {
+        final String input = "SimpleTestOfV3EncryptionClient";
+
+        v3Client.putObject(builder -> builder
+                        .bucket(BUCKET)
+                        .key(input)
+                        .build(),
+                RequestBody.fromString(input));
+
+        ResponseBytes<GetObjectResponse> objectResponse = v3Client.getObjectAsBytes(builder -> builder
+                .bucket(BUCKET)
+                .key(input)
+                .build());
+        String output = objectResponse.asUtf8String();
+        assertEquals(input, output);
+    }
+}

--- a/src/test/java/software/amazon/encryption/s3/materials/AesKeyringTest.java
+++ b/src/test/java/software/amazon/encryption/s3/materials/AesKeyringTest.java
@@ -1,0 +1,24 @@
+package software.amazon.encryption.s3.materials;
+
+import org.junit.jupiter.api.Test;
+import software.amazon.encryption.s3.S3EncryptionClientException;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+public class AesKeyringTest {
+
+    @Test
+    public void testAesKeyringWithNullWrappingKeyFails() {
+        assertThrows(S3EncryptionClientException.class, () -> AesKeyring.builder().wrappingKey(null));
+    }
+
+    @Test
+    public void buildAesKeyringWithNullSecureRandomFails() {
+        assertThrows(S3EncryptionClientException.class, () -> AesKeyring.builder().secureRandom(null));
+    }
+
+    @Test
+    public void buildAesKeyringWithNullDataKeyGeneratorFails() {
+        assertThrows(S3EncryptionClientException.class, () -> AesKeyring.builder().dataKeyGenerator(null));
+    }
+}

--- a/src/test/java/software/amazon/encryption/s3/materials/KmsKeyringTest.java
+++ b/src/test/java/software/amazon/encryption/s3/materials/KmsKeyringTest.java
@@ -1,0 +1,20 @@
+package software.amazon.encryption.s3.materials;
+
+import org.junit.jupiter.api.Test;
+import software.amazon.encryption.s3.S3EncryptionClientException;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+public class KmsKeyringTest {
+
+    @Test
+    public void buildAesKeyringWithNullSecureRandomFails() {
+        assertThrows(S3EncryptionClientException.class, () -> AesKeyring.builder().secureRandom(null));
+    }
+
+    @Test
+    public void buildAesKeyringWithNullDataKeyGeneratorFails() {
+        assertThrows(S3EncryptionClientException.class, () -> AesKeyring.builder().dataKeyGenerator(null));
+    }
+
+}

--- a/src/test/java/software/amazon/encryption/s3/materials/RsaKeyringTest.java
+++ b/src/test/java/software/amazon/encryption/s3/materials/RsaKeyringTest.java
@@ -1,0 +1,19 @@
+package software.amazon.encryption.s3.materials;
+
+import org.junit.jupiter.api.Test;
+import software.amazon.encryption.s3.S3EncryptionClientException;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+public class RsaKeyringTest {
+
+    @Test
+    public void buildAesKeyringWithNullSecureRandomFails() {
+        assertThrows(S3EncryptionClientException.class, () -> AesKeyring.builder().secureRandom(null));
+    }
+
+    @Test
+    public void buildAesKeyringWithNullDataKeyGeneratorFails() {
+        assertThrows(S3EncryptionClientException.class, () -> AesKeyring.builder().dataKeyGenerator(null));
+    }
+}


### PR DESCRIPTION
*Issue #, if available:* n/a

*Description of changes:*

* Adds some more integ testcases 
* Move the existing compatibility tests into their own test class
* Add some null checks and simple unit tests to the keyring implementations 
* Add a dependency on Jacoco and basic configuration for test coverage reporting 
* Remove the `AWS_S3EC_TEST_KMS_REGION` env var since `AWS_REGION` must be set anyway, and those regions must match for now 

Verified that the tests (new and old) pass on my machine. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
