### PR TITLE
feat: Adds CBC stream decryption

### DIFF
--- a/src/main/java/software/amazon/encryption/s3/internal/CbcCipherInputStream.java
+++ b/src/main/java/software/amazon/encryption/s3/internal/CbcCipherInputStream.java
@@ -1,0 +1,173 @@
+package software.amazon.encryption.s3.internal;
+
+import software.amazon.awssdk.core.io.SdkFilterInputStream;
+
+import javax.crypto.BadPaddingException;
+import javax.crypto.Cipher;
+import javax.crypto.IllegalBlockSizeException;
+import java.io.IOException;
+import java.io.InputStream;
+
+/**
+ * A cipher stream for decrypting CBC encrypted data. There is nothing particularly
+ * specific to CBC, but other algorithms may require additional considerations.
+ */
+public class CbcCipherInputStream extends SdkFilterInputStream {
+    private static final int MAX_RETRY_COUNT = 1000;
+    private static final int DEFAULT_IN_BUFFER_SIZE = 512;
+    private final Cipher cipher;
+
+    private boolean eofReached;
+    private byte[] inputBuffer;
+    private byte[] outputBuffer;
+    private int currentPosition;
+    private int maxPosition;
+
+    public CbcCipherInputStream(InputStream inputStream, Cipher cipher) {
+        super(inputStream);
+        this.cipher = cipher;
+        this.inputBuffer = new byte[DEFAULT_IN_BUFFER_SIZE];
+    }
+
+    @Override
+    public int read() throws IOException {
+        if (!readNextChunk()) {
+            return -1;
+        }
+        return ((int) outputBuffer[currentPosition++] & 0xFF);
+    }
+
+    @Override
+    public int read(byte b[]) throws IOException {
+        return read(b, 0, b.length);
+    }
+
+    @Override
+    public int read(byte buf[], int off, int target_len) throws IOException {
+        if (!readNextChunk()) {
+            return -1;
+        }
+        if (target_len <= 0) {
+            return 0;
+        }
+        int len = maxPosition - currentPosition;
+        if (target_len < len) {
+            len = target_len;
+        }
+        System.arraycopy(outputBuffer, currentPosition, buf, off, len);
+        currentPosition += len;
+        return len;
+    }
+
+    private boolean readNextChunk() throws IOException {
+        if (currentPosition >= maxPosition) {
+            // all buffered data has been read, let's get some more
+            if (eofReached) {
+                return false;
+            }
+            int retryCount = 0;
+            int len;
+            do {
+                if (retryCount > MAX_RETRY_COUNT) {
+                    throw new IOException("Exceeded maximum number of attempts to read next chunk of data");
+                }
+                len = nextChunk();
+                // if buf != null, it means that data is being read off of the InputStream
+                if (outputBuffer == null) {
+                    retryCount++;
+                }
+            } while (len == 0);
+
+            if (len == -1) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    /**
+     * {@inheritDoc}
+     * <p>
+     * Note: This implementation will only skip up to the end of the buffered
+     * data, potentially skipping 0 bytes.
+     */
+    @Override
+    public long skip(long n) {
+        abortIfNeeded();
+        int available = maxPosition - currentPosition;
+        if (n > available) {
+            n = available;
+        }
+        if (n < 0) {
+            return 0;
+        }
+        currentPosition += n;
+        return n;
+    }
+
+    @Override
+    public int available() {
+        abortIfNeeded();
+        return maxPosition - currentPosition;
+    }
+
+    @Override
+    public void close() throws IOException {
+        in.close();
+        try {
+            // Throw away the unprocessed data
+            cipher.doFinal();
+        } catch (BadPaddingException | IllegalBlockSizeException ex) {
+            // Swallow the exception
+        }
+    }
+
+    @Override
+    public boolean markSupported() {
+        return false;
+    }
+
+    @Override
+    public void mark(int readlimit) {
+        // mark/reset not supported
+    }
+
+    @Override
+    public void reset() throws IOException {
+        throw new IOException("mark/reset not supported");
+    }
+
+    /**
+     * Reads and process the next chunk of data into memory.
+     *
+     * @return the length of the data chunk read and processed, or -1 if end of
+     *         stream.
+     * @throws IOException
+     *             if there is an IO exception from the underlying input stream
+     */
+    private int nextChunk() throws IOException {
+        abortIfNeeded();
+        if (eofReached) {
+            return -1;
+        }
+        outputBuffer = null;
+        int len = in.read(inputBuffer);
+        if (len == -1) {
+            eofReached = true;
+            try {
+                outputBuffer = cipher.doFinal();
+                if (outputBuffer == null) {
+                    return -1;
+                }
+                currentPosition = 0;
+                return maxPosition = outputBuffer.length;
+            } catch (IllegalBlockSizeException | BadPaddingException ignore) {
+                // Swallow exceptions
+            }
+            return -1;
+        }
+        outputBuffer = cipher.update(inputBuffer, 0, len);
+        currentPosition = 0;
+        return maxPosition = (outputBuffer == null ? 0 : outputBuffer.length);
+    }
+}

--- a/src/main/java/software/amazon/encryption/s3/legacy/internal/AesCbcContentStrategy.java
+++ b/src/main/java/software/amazon/encryption/s3/legacy/internal/AesCbcContentStrategy.java
@@ -1,28 +1,21 @@
 package software.amazon.encryption.s3.legacy.internal;
 
-import java.io.ByteArrayInputStream;
-import java.io.IOException;
 import java.io.InputStream;
-import java.security.InvalidAlgorithmParameterException;
-import java.security.InvalidKeyException;
-import java.security.NoSuchAlgorithmException;
-import javax.crypto.BadPaddingException;
+import java.security.GeneralSecurityException;
 import javax.crypto.Cipher;
-import javax.crypto.IllegalBlockSizeException;
-import javax.crypto.NoSuchPaddingException;
 import javax.crypto.SecretKey;
 import javax.crypto.spec.IvParameterSpec;
 import javax.crypto.spec.SecretKeySpec;
 
-import software.amazon.awssdk.utils.IoUtils;
 import software.amazon.encryption.s3.S3EncryptionClientException;
 import software.amazon.encryption.s3.algorithms.AlgorithmSuite;
+import software.amazon.encryption.s3.internal.CbcCipherInputStream;
 import software.amazon.encryption.s3.internal.ContentDecryptionStrategy;
 import software.amazon.encryption.s3.internal.ContentMetadata;
 import software.amazon.encryption.s3.materials.DecryptionMaterials;
 
 /**
- * This class will decrypt (only) data according for AES/CBC
+ * This class will decrypt (only) data using AES/CBC
  */
 public class AesCbcContentStrategy implements ContentDecryptionStrategy {
 
@@ -33,33 +26,19 @@ public class AesCbcContentStrategy implements ContentDecryptionStrategy {
     @Override
     public InputStream decryptContent(ContentMetadata contentMetadata, DecryptionMaterials materials,
                                       InputStream ciphertextStream) {
-        // TODO: AES-CBC should always use a stream cipher.
-        byte[] ciphertext;
-        try {
-            ciphertext = IoUtils.toByteArray(ciphertextStream);
-        } catch (IOException e) {
-            throw new RuntimeException(e);
-        }
-
         AlgorithmSuite algorithmSuite = contentMetadata.algorithmSuite();
         SecretKey contentKey = new SecretKeySpec(materials.plaintextDataKey(), algorithmSuite.dataKeyAlgorithm());
         byte[] iv = contentMetadata.contentNonce();
-        final Cipher cipher;
-        byte[] plaintext;
         try {
-            cipher = Cipher.getInstance(algorithmSuite.cipherName());
+            // TODO: Allow configurable Cryptographic provider
+            final Cipher cipher = Cipher.getInstance(materials.algorithmSuite().cipherName());
             cipher.init(Cipher.DECRYPT_MODE, contentKey, new IvParameterSpec(iv));
-            plaintext = cipher.doFinal(ciphertext);
-        } catch (NoSuchAlgorithmException
-                 | NoSuchPaddingException
-                 | InvalidAlgorithmParameterException
-                 | InvalidKeyException
-                 | IllegalBlockSizeException
-                 | BadPaddingException e) {
-            throw new S3EncryptionClientException("Unable to " + algorithmSuite.cipherName() + " content decrypt.", e);
+            return new CbcCipherInputStream(ciphertextStream, cipher);
+        } catch (GeneralSecurityException ex) {
+            throw new S3EncryptionClientException("Unable to build cipher: " + ex.getMessage()
+                    + "\nMake sure you have the JCE unlimited strength policy files installed and "
+                    + "configured for your JVM.", ex);
         }
-
-        return new ByteArrayInputStream(plaintext);
     }
 
     public static class Builder {

--- a/src/main/java/software/amazon/encryption/s3/materials/CryptographicMaterials.java
+++ b/src/main/java/software/amazon/encryption/s3/materials/CryptographicMaterials.java
@@ -1,0 +1,7 @@
+package software.amazon.encryption.s3.materials;
+
+import software.amazon.encryption.s3.algorithms.AlgorithmSuite;
+
+public interface CryptographicMaterials {
+    public AlgorithmSuite algorithmSuite();
+}

--- a/src/main/java/software/amazon/encryption/s3/materials/DecryptionMaterials.java
+++ b/src/main/java/software/amazon/encryption/s3/materials/DecryptionMaterials.java
@@ -7,7 +7,7 @@ import javax.crypto.spec.SecretKeySpec;
 import software.amazon.awssdk.services.s3.model.GetObjectRequest;
 import software.amazon.encryption.s3.algorithms.AlgorithmSuite;
 
-final public class DecryptionMaterials {
+final public class DecryptionMaterials implements CryptographicMaterials {
 
     // Original request
     private final GetObjectRequest _s3Request;

--- a/src/main/java/software/amazon/encryption/s3/materials/EncryptionMaterials.java
+++ b/src/main/java/software/amazon/encryption/s3/materials/EncryptionMaterials.java
@@ -8,7 +8,7 @@ import javax.crypto.spec.SecretKeySpec;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 import software.amazon.encryption.s3.algorithms.AlgorithmSuite;
 
-final public class EncryptionMaterials {
+final public class EncryptionMaterials implements CryptographicMaterials {
 
     // Original request
     private final PutObjectRequest _s3Request;

--- a/src/test/java/software/amazon/encryption/s3/S3EncryptionClientStreamTest.java
+++ b/src/test/java/software/amazon/encryption/s3/S3EncryptionClientStreamTest.java
@@ -1,0 +1,269 @@
+package software.amazon.encryption.s3;
+
+import com.amazonaws.services.s3.AmazonS3Encryption;
+import com.amazonaws.services.s3.AmazonS3EncryptionClient;
+import com.amazonaws.services.s3.AmazonS3EncryptionClientV2;
+import com.amazonaws.services.s3.AmazonS3EncryptionV2;
+import com.amazonaws.services.s3.model.CryptoConfiguration;
+import com.amazonaws.services.s3.model.CryptoMode;
+import com.amazonaws.services.s3.model.EncryptionMaterials;
+import com.amazonaws.services.s3.model.EncryptionMaterialsProvider;
+import com.amazonaws.services.s3.model.ObjectMetadata;
+import com.amazonaws.services.s3.model.StaticEncryptionMaterialsProvider;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import software.amazon.awssdk.core.ResponseInputStream;
+import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.GetObjectResponse;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+import software.amazon.awssdk.utils.IoUtils;
+import software.amazon.encryption.s3.utils.BoundedStreamBufferer;
+import software.amazon.encryption.s3.utils.BoundedZerosInputStream;
+import software.amazon.encryption.s3.utils.MarkResetBoundedZerosInputStream;
+
+import javax.crypto.KeyGenerator;
+import javax.crypto.SecretKey;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.security.NoSuchAlgorithmException;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Test the streaming functionality using various stream implementations.
+ */
+public class S3EncryptionClientStreamTest {
+
+    private static final String BUCKET = S3EncryptionClientTestResources.BUCKET;
+    private static final int DEFAULT_TEST_STREAM_LENGTH = 2069;
+
+    private static SecretKey AES_KEY;
+
+    @BeforeAll
+    public static void setUp() throws NoSuchAlgorithmException {
+        KeyGenerator keyGen = KeyGenerator.getInstance("AES");
+        keyGen.init(256);
+        AES_KEY = keyGen.generateKey();
+    }
+
+    @Test
+    public void markResetInputStreamV2Encrypt() throws IOException {
+        final String objectKey = "markResetInputStreamV2Encrypt";
+
+        // V2 Client
+        EncryptionMaterialsProvider materialsProvider =
+                new StaticEncryptionMaterialsProvider(new EncryptionMaterials(AES_KEY));
+        AmazonS3EncryptionV2 v2Client = AmazonS3EncryptionClientV2.encryptionBuilder()
+                .withEncryptionMaterialsProvider(materialsProvider)
+                .build();
+
+        final int inputLength = DEFAULT_TEST_STREAM_LENGTH;
+        final MarkResetBoundedZerosInputStream inputStream = new MarkResetBoundedZerosInputStream(inputLength);
+        inputStream.mark(inputLength);
+        final String inputStreamAsUtf8String = IoUtils.toUtf8String(inputStream);
+        inputStream.reset();
+
+        final ObjectMetadata metadata = new ObjectMetadata();
+        metadata.setContentLength(inputLength);
+        v2Client.putObject(BUCKET, objectKey, inputStream, metadata);
+        inputStream.close();
+
+        final String actualObject = IoUtils.toUtf8String(v2Client.getObject(BUCKET, objectKey).getObjectContent());
+
+        assertEquals(inputStreamAsUtf8String, actualObject);
+    }
+
+    @Test
+    public void markResetInputStreamV3Encrypt() throws IOException {
+        final String objectKey = "markResetInputStreamV3Encrypt";
+
+        // V3 Client
+        S3Client v3Client = S3EncryptionClient.builder()
+                .aesKey(AES_KEY)
+                .build();
+
+        final int inputLength = DEFAULT_TEST_STREAM_LENGTH;
+        final InputStream inputStream = new MarkResetBoundedZerosInputStream(inputLength);
+        inputStream.mark(inputLength);
+        final String inputStreamAsUtf8String = IoUtils.toUtf8String(inputStream);
+        inputStream.reset();
+
+        v3Client.putObject(PutObjectRequest.builder()
+                .bucket(BUCKET)
+                .key(objectKey)
+                .build(), RequestBody.fromInputStream(inputStream, inputLength));
+        inputStream.close();
+
+        final String actualObject = v3Client.getObjectAsBytes(builder -> builder
+                .bucket(BUCKET)
+                .key(objectKey)
+                .build()).asUtf8String();
+        v3Client.close();
+
+        assertEquals(inputStreamAsUtf8String, actualObject);
+    }
+
+    @Test
+    public void ordinaryInputStreamV2Encrypt() throws IOException {
+        final String objectKey = "markResetInputStreamV2Encrypt";
+
+        // V2 Client
+        EncryptionMaterialsProvider materialsProvider =
+                new StaticEncryptionMaterialsProvider(new EncryptionMaterials(AES_KEY));
+        AmazonS3EncryptionV2 v2Client = AmazonS3EncryptionClientV2.encryptionBuilder()
+                .withEncryptionMaterialsProvider(materialsProvider)
+                .build();
+
+        final int inputLength = DEFAULT_TEST_STREAM_LENGTH;
+        final BoundedZerosInputStream inputStream = new BoundedZerosInputStream(inputLength);
+        // Create a second stream of zeros because reset is not supported
+        // and reading into the byte string will consume the stream.
+        final BoundedZerosInputStream inputStreamForString = new BoundedZerosInputStream(inputLength);
+        final String inputStreamAsUtf8String = IoUtils.toUtf8String(inputStreamForString);
+
+        final ObjectMetadata metadata = new ObjectMetadata();
+        metadata.setContentLength(inputLength);
+        v2Client.putObject(BUCKET, objectKey, inputStream, metadata);
+        inputStream.close();
+
+        final String actualObject = IoUtils.toUtf8String(v2Client.getObject(BUCKET, objectKey).getObjectContent());
+
+        assertEquals(inputStreamAsUtf8String, actualObject);
+    }
+
+    @Test
+    public void ordinaryInputStreamV3Encrypt() throws IOException {
+        final String objectKey = "ordinaryInputStreamV3Encrypt";
+
+        // V3 Client
+        S3Client v3Client = S3EncryptionClient.builder()
+                .aesKey(AES_KEY)
+                .build();
+
+        final int inputLength = DEFAULT_TEST_STREAM_LENGTH;
+        // Create a second stream of zeros because reset is not supported
+        // and reading into the byte string will consume the stream.
+        final InputStream inputStream = new BoundedZerosInputStream(inputLength);
+        final InputStream inputStreamForString = new BoundedZerosInputStream(inputLength);
+        final String inputStreamAsUtf8String = IoUtils.toUtf8String(inputStreamForString);
+
+        v3Client.putObject(PutObjectRequest.builder()
+                .bucket(BUCKET)
+                .key(objectKey)
+                .build(), RequestBody.fromInputStream(inputStream, inputLength));
+        inputStream.close();
+
+        final String actualObject = v3Client.getObjectAsBytes(builder -> builder
+                .bucket(BUCKET)
+                .key(objectKey)
+                .build()).asUtf8String();
+        v3Client.close();
+
+        assertEquals(inputStreamAsUtf8String, actualObject);
+    }
+
+    @Test
+    public void ordinaryInputStreamV3Decrypt() throws IOException {
+        final String objectKey = "ordinaryInputStreamV3Decrypt";
+
+        // V3 Client
+        S3Client v3Client = S3EncryptionClient.builder()
+                .aesKey(AES_KEY)
+                .build();
+
+        final int inputLength = DEFAULT_TEST_STREAM_LENGTH;
+        // Create a second stream of zeros because reset is not supported
+        // and reading into the byte string will consume the stream.
+        final InputStream inputStream = new BoundedZerosInputStream(inputLength);
+        final InputStream inputStreamForString = new BoundedZerosInputStream(inputLength);
+        final String inputStreamAsUtf8String = IoUtils.toUtf8String(inputStreamForString);
+
+        v3Client.putObject(PutObjectRequest.builder()
+                .bucket(BUCKET)
+                .key(objectKey)
+                .build(), RequestBody.fromInputStream(inputStream, inputLength));
+        inputStream.close();
+
+        final ResponseInputStream<GetObjectResponse> responseInputStream = v3Client.getObject(builder -> builder
+                .bucket(BUCKET)
+                .key(objectKey)
+                .build());
+        final String actualObject = new String(BoundedStreamBufferer.toByteArray(responseInputStream, inputLength / 8),
+                StandardCharsets.UTF_8);
+        v3Client.close();
+
+        assertEquals(inputStreamAsUtf8String, actualObject);
+    }
+
+    @Test
+    public void markResetInputStreamV3DecryptGcm() throws IOException {
+        final String objectKey = "markResetInputStreamV3DecryptGcm";
+
+        // V3 Client
+        S3Client v3Client = S3EncryptionClient.builder()
+                .aesKey(AES_KEY)
+                .build();
+
+        final int inputLength = DEFAULT_TEST_STREAM_LENGTH;
+        // Create a second stream of zeros because reset is not supported
+        // and reading into the byte string will consume the stream.
+        final InputStream inputStream = new BoundedZerosInputStream(inputLength);
+        final InputStream inputStreamForString = new BoundedZerosInputStream(inputLength);
+        final String inputStreamAsUtf8String = IoUtils.toUtf8String(inputStreamForString);
+
+        v3Client.putObject(PutObjectRequest.builder()
+                .bucket(BUCKET)
+                .key(objectKey)
+                .build(), RequestBody.fromInputStream(inputStream, inputLength));
+        inputStream.close();
+
+        final ResponseInputStream<GetObjectResponse> responseInputStream = v3Client.getObject(builder -> builder
+                .bucket(BUCKET)
+                .key(objectKey)
+                .build());
+        final String actualObject = new String(BoundedStreamBufferer.toByteArrayWithMarkReset(responseInputStream, inputLength / 8),
+                StandardCharsets.UTF_8);
+        v3Client.close();
+
+        assertEquals(inputStreamAsUtf8String, actualObject);
+    }
+
+    @Test
+    public void ordinaryInputStreamV3DecryptCbc() throws IOException {
+        final String objectKey = "markResetInputStreamV3DecryptCbc";
+
+        // V1 Client
+        EncryptionMaterialsProvider materialsProvider =
+                new StaticEncryptionMaterialsProvider(new EncryptionMaterials(AES_KEY));
+        CryptoConfiguration v1CryptoConfig =
+                new CryptoConfiguration(CryptoMode.EncryptionOnly);
+        AmazonS3Encryption v1Client = AmazonS3EncryptionClient.encryptionBuilder()
+                .withCryptoConfiguration(v1CryptoConfig)
+                .withEncryptionMaterials(materialsProvider)
+                .build();
+
+        // V3 Client
+        S3Client v3Client = S3EncryptionClient.builder()
+                .aesKey(AES_KEY)
+                .enableLegacyUnauthenticatedModes(true)
+                .build();
+
+        final int inputLength = DEFAULT_TEST_STREAM_LENGTH;
+        final InputStream inputStreamForString = new BoundedZerosInputStream(inputLength);
+        final String inputStreamAsUtf8String = IoUtils.toUtf8String(inputStreamForString);
+
+        v1Client.putObject(BUCKET, objectKey, inputStreamAsUtf8String);
+
+        final ResponseInputStream<GetObjectResponse> responseInputStream = v3Client.getObject(builder -> builder
+                .bucket(BUCKET)
+                .key(objectKey)
+                .build());
+        final String actualObject = new String(BoundedStreamBufferer.toByteArray(responseInputStream, inputLength / 8),
+                StandardCharsets.UTF_8);
+        v3Client.close();
+
+        assertEquals(inputStreamAsUtf8String, actualObject);
+    }
+}

--- a/src/test/java/software/amazon/encryption/s3/S3EncryptionClientTest.java
+++ b/src/test/java/software/amazon/encryption/s3/S3EncryptionClientTest.java
@@ -7,6 +7,7 @@ import software.amazon.awssdk.core.sync.RequestBody;
 import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.model.GetObjectResponse;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+import software.amazon.encryption.s3.utils.BoundedZerosInputStream;
 
 import javax.crypto.KeyGenerator;
 import javax.crypto.SecretKey;
@@ -162,29 +163,6 @@ public class S3EncryptionClientTest {
                 .bucket(BUCKET)
                 .key(BUCKET_KEY)));
         v3Client.close();
-    }
-
-    /**
-     * Stream of a fixed number of zeros. Useful for testing
-     * stream uploads of a specific size. Not threadsafe.
-     */
-    private static class BoundedZerosInputStream extends InputStream {
-
-        private final long _bound;
-        private long _progress = 0;
-
-        BoundedZerosInputStream(final long bound) {
-            _bound = bound;
-        }
-
-        @Override
-        public int read() {
-            if (_progress >= _bound) {
-                return -1;
-            }
-            _progress++;
-            return 0;
-        }
     }
 
     /**

--- a/src/test/java/software/amazon/encryption/s3/utils/BoundedStreamBufferer.java
+++ b/src/test/java/software/amazon/encryption/s3/utils/BoundedStreamBufferer.java
@@ -1,0 +1,38 @@
+package software.amazon.encryption.s3.utils;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+
+/**
+ * Reads an InputStream instances into memory.
+ */
+public class BoundedStreamBufferer {
+
+    public static byte[] toByteArray(InputStream is, int bufferSize) throws IOException {
+        try (ByteArrayOutputStream output = new ByteArrayOutputStream()) {
+            byte[] b = new byte[bufferSize];
+            int n;
+            while ((n = is.read(b)) != -1) {
+                output.write(b, 0, n);
+            }
+            return output.toByteArray();
+        }
+    }
+
+    public static byte[] toByteArrayWithMarkReset(InputStream is, int bufferSize) throws IOException {
+        try (ByteArrayOutputStream output = new ByteArrayOutputStream()) {
+            byte[] b = new byte[bufferSize];
+            // burn some bytes to force mark/reset
+            byte[] discard = new byte[bufferSize];
+            int n;
+            while ((n = is.read(b)) != -1) {
+                is.mark(bufferSize);
+                is.read(discard, 0, bufferSize);
+                is.reset();
+                output.write(b, 0, n);
+            }
+            return output.toByteArray();
+        }
+    }
+}

--- a/src/test/java/software/amazon/encryption/s3/utils/BoundedZerosInputStream.java
+++ b/src/test/java/software/amazon/encryption/s3/utils/BoundedZerosInputStream.java
@@ -1,0 +1,28 @@
+package software.amazon.encryption.s3.utils;
+
+import java.io.InputStream;
+
+/**
+ * Test utility class.
+ * Stream of a fixed number of zeros. Useful for testing
+ * stream uploads of a specific size. Not threadsafe.
+ */
+public class BoundedZerosInputStream extends InputStream {
+
+    private final long _bound;
+    private long _progress = 0;
+
+    public BoundedZerosInputStream(final long bound) {
+        _bound = bound;
+    }
+
+    @Override
+    public int read() {
+        if (_progress >= _bound) {
+            return -1;
+        }
+        _progress++;
+        return 0;
+    }
+}
+

--- a/src/test/java/software/amazon/encryption/s3/utils/MarkResetBoundedZerosInputStream.java
+++ b/src/test/java/software/amazon/encryption/s3/utils/MarkResetBoundedZerosInputStream.java
@@ -1,0 +1,46 @@
+package software.amazon.encryption.s3.utils;
+
+import java.io.InputStream;
+
+/**
+ * Test utility class.
+ * Stream of a fixed number of zeros. Supports arbitrary mark/reset.
+ * Useful for testing stream uploads of a specific size. Not threadsafe.
+ */
+public class MarkResetBoundedZerosInputStream extends InputStream {
+
+    private final long _boundInBytes;
+    private long _progress = 0;
+    private long _mark = 0;
+
+    public MarkResetBoundedZerosInputStream(final long boundInBytes) {
+        _boundInBytes = boundInBytes;
+    }
+
+    @Override
+    public int read() {
+        if (_progress >= _boundInBytes) {
+            return -1;
+        }
+        _progress++;
+        return 0;
+    }
+
+    @Override
+    public boolean markSupported() {
+        return true;
+    }
+
+    @Override
+    public void mark(int readLimit) {
+        // Since this InputStream implementation is bounded, we can support
+        // arbitrary mark/reset, so just discard the readLimit parameter.
+        _mark = _progress;
+    }
+
+    @Override
+    public void reset() {
+        _progress = _mark;
+        _mark = 0;
+    }
+}


### PR DESCRIPTION
*Issue #, if available:* n/a

*Description of changes:* Replaces the buffered scheme with an `InputStream` based implementation in the AES-CBC content decryption strategy.  


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
