### PR TITLE
fix: Guard against using another S3EC as wrappedClient

### DIFF
--- a/src/main/java/software/amazon/encryption/s3/S3EncryptionClient.java
+++ b/src/main/java/software/amazon/encryption/s3/S3EncryptionClient.java
@@ -123,6 +123,10 @@ public class S3EncryptionClient implements S3Client {
         private Builder() {}
 
         public Builder wrappedClient(S3Client wrappedClient) {
+            if (wrappedClient instanceof S3EncryptionClient) {
+                throw new S3EncryptionClientException("Cannot use S3EncryptionClient as wrapped client");
+            }
+
             this._wrappedClient = wrappedClient;
             return this;
         }

--- a/src/test/java/software/amazon/encryption/s3/S3EncryptionClientTest.java
+++ b/src/test/java/software/amazon/encryption/s3/S3EncryptionClientTest.java
@@ -233,25 +233,20 @@ public class S3EncryptionClientTest {
         simpleV3RoundTrip(wrappingClient, objectKey);
     }
 
+    /**
+     * S3EncryptionClient implements S3Client, so it can be passed into the builder as a wrappedClient.
+     * However, is not a supported use case, and the builder should throw an exception if this happens.
+     */
     @Test
-    public void s3EncryptionClientWithWrappedS3EncryptionClientSucceeds() {
-        final String objectKey = "wrapped-s3-ec-from-kms-key-id";
-
-        /**
-         * S3EncryptionClient implements S3Client, so it can be used as a wrapped client.
-         * However, both the wrappedClient and the wrappingClient need valid keys:
-         * ex. wrappingClient.get calls wrappedClient.get calls wrappedClient's S3Client.get
-         */
+    public void s3EncryptionClientWithWrappedS3EncryptionClientFails() {
         S3Client wrappedClient = S3EncryptionClient.builder()
             .kmsKeyId(KMS_KEY_ID)
             .build();
 
-        S3Client wrappingClient = S3EncryptionClient.builder()
+        assertThrows(S3EncryptionClientException.class, () -> S3EncryptionClient.builder()
             .wrappedClient(wrappedClient)
             .kmsKeyId(KMS_KEY_ID)
-            .build();
-
-        simpleV3RoundTrip(wrappingClient, objectKey);
+            .build());
     }
 
     /**


### PR DESCRIPTION
*Description of changes:*
* Fix: Guard against using S3EncryptionClient as a wrappedClient for another S3EncryptionClient. This isn't a supported use case.
* Test: Add E2E test coverage (simple round trip call) for the following cases:
  * S3EC built using keyring
  * S3EC built using CMM
  * S3EC taking in an S3Client as a wrapped client, built using KMS key ID

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
