### PR TITLE
cfn: Update CFN template to add DeleteObject bucket permission

### DIFF
--- a/cfn/S3EC-GitHub-CF-Template
+++ b/cfn/S3EC-GitHub-CF-Template
@@ -46,6 +46,7 @@ Resources:
             Action:
               - 's3:PutObject'
               - 's3:GetObject'
+              - 's3:DeleteObject'
             Resource:
               - !Join [ "", [ !GetAtt S3ECGitHubTestS3Bucket.Arn, '/*'] ]
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

- Update CFN template to add DeleteObject bucket permission. This permission is added to test S3EC `deleteObject` implementation.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
