### PR TITLE
fix: bump node version from 14 to 18 in release workflow

### DIFF
--- a/codebuild/release/version.yml
+++ b/codebuild/release/version.yml
@@ -20,7 +20,7 @@ phases:
       - npm install @semantic-release/git -d
       - npm install --save conventional-changelog
     runtime-versions:
-      nodejs: 14
+      nodejs: 18
   pre_build:
     commands:
       - git config --global user.name "aws-crypto-tools-ci-bot"


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Build is failing due to its node version (14) no longer being supported by semantic PR. This bumps the node version to 18. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
