### PR TITLE
chore: change algorithm suite IDs to match the specification

### DIFF
--- a/src/main/java/software/amazon/encryption/s3/algorithms/AlgorithmSuite.java
+++ b/src/main/java/software/amazon/encryption/s3/algorithms/AlgorithmSuite.java
@@ -1,7 +1,7 @@
 package software.amazon.encryption.s3.algorithms;
 
 public enum AlgorithmSuite {
-    ALG_AES_256_GCM_IV12_TAG16_NO_KDF(0x0078,
+    ALG_AES_256_GCM_IV12_TAG16_NO_KDF(0x0072,
             false,
             "AES",
             256,
@@ -10,7 +10,7 @@ public enum AlgorithmSuite {
             96,
             128,
             AlgorithmConstants.GCM_MAX_CONTENT_LENGTH_BITS),
-    ALG_AES_256_CTR_IV16_TAG16_NO_KDF(0x0074,
+    ALG_AES_256_CTR_IV16_TAG16_NO_KDF(0x0071,
             true,
             "AES",
             256,


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

The previous values referred to the same algorithms present in the AWS Encryption SDK, but the expectation is that each encryption library MUST have its own algorithm suite IDs. Therefore, the values must be changed to be distinct from the ESDK values.  

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
