### PR TITLE
chore: bump AWS SDK v2 deps and make S3 non-optional

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -51,7 +51,7 @@
       <dependency>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>bom</artifactId>
-        <version>2.19.3</version>
+        <version>2.20.12</version>
         <optional>true</optional>
         <type>pom</type>
         <scope>import</scope>
@@ -63,14 +63,13 @@
     <dependency>
       <groupId>software.amazon.awssdk</groupId>
       <artifactId>s3</artifactId>
-      <version>2.19.3</version>
-      <optional>true</optional>
+      <version>2.20.12</version>
     </dependency>
 
     <dependency>
       <groupId>software.amazon.awssdk</groupId>
       <artifactId>kms</artifactId>
-      <version>2.19.3</version>
+      <version>2.20.12</version>
       <optional>true</optional>
     </dependency>
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Update AWS SDK dependencies, specifically to pull in https://github.com/aws/aws-sdk-java-v2/pull/3745

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
