### PR TITLE
feat: extend delegating client to enable non-encrypted API operations…

### DIFF
--- a/src/main/java/software/amazon/encryption/s3/S3AsyncEncryptionClient.java
+++ b/src/main/java/software/amazon/encryption/s3/S3AsyncEncryptionClient.java
@@ -6,6 +6,7 @@ import software.amazon.awssdk.awscore.exception.AwsServiceException;
 import software.amazon.awssdk.core.async.AsyncRequestBody;
 import software.amazon.awssdk.core.async.AsyncResponseTransformer;
 import software.amazon.awssdk.core.exception.SdkClientException;
+import software.amazon.awssdk.services.s3.DelegatingS3AsyncClient;
 import software.amazon.awssdk.services.s3.S3AsyncClient;
 import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
 import software.amazon.awssdk.services.s3.model.DeleteObjectResponse;
@@ -36,7 +37,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.function.Consumer;
 import java.util.function.Function;
 
-public class S3AsyncEncryptionClient implements S3AsyncClient {
+public class S3AsyncEncryptionClient extends DelegatingS3AsyncClient {
 
     private final S3AsyncClient _wrappedClient;
     private final S3AsyncClient _wrappedCrtClient;
@@ -48,6 +49,7 @@ public class S3AsyncEncryptionClient implements S3AsyncClient {
     private final boolean _enableMultipartPutObject;
 
     private S3AsyncEncryptionClient(Builder builder) {
+        super(builder._wrappedClient);
         _wrappedClient = builder._wrappedClient;
         _wrappedCrtClient = builder._wrappedCrtClient;
         _cryptoMaterialsManager = builder._cryptoMaterialsManager;
@@ -121,11 +123,6 @@ public class S3AsyncEncryptionClient implements S3AsyncClient {
         return _wrappedClient.deleteObjects(deleteObjectsRequest.toBuilder()
                 .delete(builder -> builder.objects(objectsToDelete))
                 .build());
-    }
-
-    @Override
-    public String serviceName() {
-        return _wrappedClient.serviceName();
     }
 
     @Override

--- a/src/test/java/software/amazon/encryption/s3/S3AsyncEncryptionClientTest.java
+++ b/src/test/java/software/amazon/encryption/s3/S3AsyncEncryptionClientTest.java
@@ -20,6 +20,7 @@ import software.amazon.awssdk.core.sync.RequestBody;
 import software.amazon.awssdk.core.sync.ResponseTransformer;
 import software.amazon.awssdk.services.s3.S3AsyncClient;
 import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.CopyObjectResponse;
 import software.amazon.awssdk.services.s3.model.DeleteObjectResponse;
 import software.amazon.awssdk.services.s3.model.DeleteObjectsResponse;
 import software.amazon.awssdk.services.s3.model.GetObjectResponse;
@@ -38,7 +39,6 @@ import java.util.concurrent.CompletionException;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 import static software.amazon.encryption.s3.utils.S3EncryptionClientTestResources.BUCKET;
 import static software.amazon.encryption.s3.utils.S3EncryptionClientTestResources.appendTestSuffix;
 import static software.amazon.encryption.s3.utils.S3EncryptionClientTestResources.deleteObject;
@@ -117,6 +117,36 @@ public class S3AsyncEncryptionClientTest {
         // Cleanup
         deleteObject(BUCKET, objectKey, v3Client);
         v3Client.close();
+        v3AsyncClient.close();
+    }
+
+    @Test
+    public void putAsyncGetAsync() {
+        final String objectKey = appendTestSuffix("put-async-get-async");
+
+        S3AsyncClient v3AsyncClient = S3AsyncEncryptionClient.builder()
+                .aesKey(AES_KEY)
+                .build();
+
+        final String input = "PutAsyncGetAsync";
+
+        CompletableFuture<PutObjectResponse> futurePut = v3AsyncClient.putObject(builder -> builder
+                .bucket(BUCKET)
+                .key(objectKey)
+                .build(), AsyncRequestBody.fromString(input));
+        // Block on completion of the futurePut
+        futurePut.join();
+
+        CompletableFuture<ResponseBytes<GetObjectResponse>> futureGet = v3AsyncClient.getObject(builder -> builder
+                .bucket(BUCKET)
+                .key(objectKey)
+                .build(), AsyncResponseTransformer.toBytes());
+        // Just wait for the future to complete
+        ResponseBytes<GetObjectResponse> getResponse = futureGet.join();
+        assertEquals(input, getResponse.asUtf8String());
+
+        // Cleanup
+        deleteObject(BUCKET, objectKey, v3AsyncClient);
         v3AsyncClient.close();
     }
 
@@ -333,4 +363,46 @@ public class S3AsyncEncryptionClientTest {
         // Cleanup
         v3Client.close();
     }
+
+    @Test
+    public void copyObjectTransparentlyAsync() {
+        final String objectKey = appendTestSuffix("copy-object-from-here-async");
+        final String newObjectKey = appendTestSuffix("copy-object-to-here-async");
+
+        S3AsyncClient v3AsyncClient = S3AsyncEncryptionClient.builder()
+                .aesKey(AES_KEY)
+                .build();
+
+        final String input = "CopyObjectAsync";
+
+        CompletableFuture<PutObjectResponse> futurePut = v3AsyncClient.putObject(builder -> builder
+                .bucket(BUCKET)
+                .key(objectKey)
+                .build(), AsyncRequestBody.fromString(input));
+        // Block on completion of the futurePut
+        futurePut.join();
+
+        CompletableFuture<CopyObjectResponse> futureCopy = v3AsyncClient.copyObject(builder -> builder
+                .sourceBucket(BUCKET)
+                .destinationBucket(BUCKET)
+                .sourceKey(objectKey)
+                .destinationKey(newObjectKey)
+                .build());
+        // Block on copy future
+        futureCopy.join();
+
+        // Decrypt new object
+        CompletableFuture<ResponseBytes<GetObjectResponse>> futureGet = v3AsyncClient.getObject(builder -> builder
+                .bucket(BUCKET)
+                .key(newObjectKey)
+                .build(), AsyncResponseTransformer.toBytes());
+        ResponseBytes<GetObjectResponse> getResponse = futureGet.join();
+        assertEquals(input, getResponse.asUtf8String());
+
+        // Cleanup
+        deleteObject(BUCKET, objectKey, v3AsyncClient);
+        deleteObject(BUCKET, newObjectKey, v3AsyncClient);
+        v3AsyncClient.close();
+    }
+
 }

--- a/src/test/java/software/amazon/encryption/s3/S3EncryptionClientCompatibilityTest.java
+++ b/src/test/java/software/amazon/encryption/s3/S3EncryptionClientCompatibilityTest.java
@@ -24,7 +24,6 @@ import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.model.GetObjectRequest;
 import software.amazon.awssdk.services.s3.model.GetObjectResponse;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
-import software.amazon.awssdk.services.s3.model.S3Exception;
 
 import javax.crypto.KeyGenerator;
 import javax.crypto.SecretKey;
@@ -36,7 +35,6 @@ import java.security.KeyPairGenerator;
 import java.security.NoSuchAlgorithmException;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.concurrent.CompletionException;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;

--- a/src/test/java/software/amazon/encryption/s3/S3EncryptionClientTest.java
+++ b/src/test/java/software/amazon/encryption/s3/S3EncryptionClientTest.java
@@ -76,6 +76,43 @@ public class S3EncryptionClientTest {
     }
 
     @Test
+    public void copyObjectTransparently() {
+        final String objectKey = appendTestSuffix("copy-object-from-here");
+        final String newObjectKey = appendTestSuffix("copy-object-to-here");
+
+        S3Client s3EncryptionClient = S3EncryptionClient.builder()
+                .kmsKeyId(KMS_KEY_ID)
+                .build();
+
+        final String input = "SimpleTestOfV3EncryptionClientCopyObject";
+
+        s3EncryptionClient.putObject(builder -> builder
+                        .bucket(BUCKET)
+                        .key(objectKey)
+                        .build(),
+                RequestBody.fromString(input));
+
+        s3EncryptionClient.copyObject(builder -> builder
+                .sourceBucket(BUCKET)
+                .destinationBucket(BUCKET)
+                .sourceKey(objectKey)
+                .destinationKey(newObjectKey)
+                .build());
+
+        ResponseBytes<GetObjectResponse> objectResponse = s3EncryptionClient.getObjectAsBytes(builder -> builder
+                .bucket(BUCKET)
+                .key(newObjectKey)
+                .build());
+        String output = objectResponse.asUtf8String();
+        assertEquals(input, output);
+
+        // Cleanup
+        deleteObject(BUCKET, objectKey, s3EncryptionClient);
+        deleteObject(BUCKET, newObjectKey, s3EncryptionClient);
+        s3EncryptionClient.close();
+    }
+
+    @Test
     public void deleteObjectWithInstructionFileSuccess() {
         final String objectKey = appendTestSuffix("delete-object-with-instruction-file");
 


### PR DESCRIPTION
… in default and async encryption clients

*Issue #, if available:*

n/a

*Description of changes:*

In order to allow the S3 EC to function as a more "generic" S3 client, e.g. one that supports control plane operations and data plane operations which do not make sense to have encryption, we need to extend the delegating client class instead of merely implementing the interface. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
