### PR TITLE
fix: pass exception from doFinal to wrapped subscriber to avoid hanging

### DIFF
--- a/src/main/java/software/amazon/encryption/s3/internal/CipherSubscriber.java
+++ b/src/main/java/software/amazon/encryption/s3/internal/CipherSubscriber.java
@@ -78,6 +78,8 @@ public class CipherSubscriber implements Subscriber<ByteBuffer> {
             // Send the final bytes to the wrapped subscriber
             wrappedSubscriber.onNext(ByteBuffer.wrap(outputBuffer));
         } catch (final GeneralSecurityException exception) {
+            // Forward error, else the wrapped subscriber waits indefinitely
+            wrappedSubscriber.onError(exception);
             throw new S3EncryptionClientSecurityException(exception.getMessage(), exception);
         }
         wrappedSubscriber.onComplete();


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

While testing some tag tampering scenarios, I realized that throwing an exception is not sufficient- we need to pass the error to the wrapped subscriber or else it will wait indefinitely. Now, when the tag does not match, the future will complete exceptionally instead of waiting forever. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
