### PR TITLE
fix: remove duplicate call to appendTestPrefix in deleteObjects

### DIFF
--- a/src/test/java/software/amazon/encryption/s3/S3EncryptionClientTest.java
+++ b/src/test/java/software/amazon/encryption/s3/S3EncryptionClientTest.java
@@ -138,7 +138,7 @@ public class S3EncryptionClientTest {
         final String input = "DeleteObjectsWithInstructionFileSuccess";
         List<ObjectIdentifier> objects = new ArrayList<>();
         for (String objectKey : objectKeys) {
-            v2Client.putObject(BUCKET, appendTestSuffix(objectKey), input);
+            v2Client.putObject(BUCKET, objectKey, input);
             objects.add(ObjectIdentifier.builder().key(objectKey).build());
         }
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
