### PR TITLE
fix: regression in ranged gets when using buffered subscriber

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -208,12 +208,12 @@
                     <limit>
                       <counter>INSTRUCTION</counter>
                       <value>COVEREDRATIO</value>
-                      <minimum>0.0</minimum>
+                      <minimum>0.8</minimum>
                     </limit>
                     <limit>
                       <counter>BRANCH</counter>
                       <value>COVEREDRATIO</value>
-                      <minimum>0.0</minimum>
+                      <minimum>0.5</minimum>
                     </limit>
                   </limits>
                 </rule>

--- a/src/test/java/software/amazon/encryption/s3/S3EncryptionClientMultipartUploadTest.java
+++ b/src/test/java/software/amazon/encryption/s3/S3EncryptionClientMultipartUploadTest.java
@@ -3,6 +3,7 @@ package software.amazon.encryption.s3;
 import org.apache.commons.io.IOUtils;
 import org.bouncycastle.jce.provider.BouncyCastleProvider;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 import software.amazon.awssdk.core.ResponseBytes;
 import software.amazon.awssdk.core.ResponseInputStream;
 import software.amazon.awssdk.core.sync.RequestBody;

--- a/src/test/java/software/amazon/encryption/s3/S3EncryptionClientRangedGetCompatibilityTest.java
+++ b/src/test/java/software/amazon/encryption/s3/S3EncryptionClientRangedGetCompatibilityTest.java
@@ -7,6 +7,7 @@ import com.amazonaws.services.s3.model.EncryptionMaterials;
 import com.amazonaws.services.s3.model.EncryptionMaterialsProvider;
 import com.amazonaws.services.s3.model.StaticEncryptionMaterialsProvider;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 import software.amazon.awssdk.core.ResponseBytes;
 import software.amazon.awssdk.core.async.AsyncRequestBody;
 import software.amazon.awssdk.core.async.AsyncResponseTransformer;
@@ -63,14 +64,12 @@ public class S3EncryptionClientRangedGetCompatibilityTest {
                 .build(), AsyncRequestBody.fromString(input)).join();
 
         // Valid Range
-        ResponseBytes<GetObjectResponse> objectResponse;
-        String output;
-//        objectResponse = asyncClient.getObject(builder -> builder
-//                .bucket(BUCKET)
-//                .range("bytes=10-20")
-//                .key(objectKey), AsyncResponseTransformer.toBytes()).join();
-//        String output = objectResponse.asUtf8String();
-//        assertEquals("klmnopqrst0", output);
+        ResponseBytes<GetObjectResponse> objectResponse = asyncClient.getObject(builder -> builder
+                .bucket(BUCKET)
+                .range("bytes=10-20")
+                .key(objectKey), AsyncResponseTransformer.toBytes()).join();
+        String output = objectResponse.asUtf8String();
+        assertEquals("klmnopqrst0", output);
 
         // Valid start index within input and end index out of range, returns object from start index to End of Stream
         objectResponse = asyncClient.getObject(builder -> builder
@@ -81,28 +80,28 @@ public class S3EncryptionClientRangedGetCompatibilityTest {
         assertEquals("KLMNOPQRST", output);
 
         // Invalid range start index range greater than ending index, returns entire object
-//        objectResponse = asyncClient.getObject(builder -> builder
-//                .bucket(BUCKET)
-//                .range("bytes=100-50")
-//                .key(objectKey), AsyncResponseTransformer.toBytes()).join();
-//        output = objectResponse.asUtf8String();
-//        assertEquals(input, output);
-//
-//        // Invalid range format, returns entire object
-//        objectResponse = asyncClient.getObject(builder -> builder
-//                .bucket(BUCKET)
-//                .range("10-20")
-//                .key(objectKey), AsyncResponseTransformer.toBytes()).join();
-//        output = objectResponse.asUtf8String();
-//        assertEquals(input, output);
-//
-//        // Invalid range starting index and ending index greater than object length but within Cipher Block size, returns empty object
-//        objectResponse = asyncClient.getObject(builder -> builder
-//                .bucket(BUCKET)
-//                .range("bytes=216-217")
-//                .key(objectKey), AsyncResponseTransformer.toBytes()).join();
-//        output = objectResponse.asUtf8String();
-//        assertEquals("", output);
+        objectResponse = asyncClient.getObject(builder -> builder
+                .bucket(BUCKET)
+                .range("bytes=100-50")
+                .key(objectKey), AsyncResponseTransformer.toBytes()).join();
+        output = objectResponse.asUtf8String();
+        assertEquals(input, output);
+
+        // Invalid range format, returns entire object
+        objectResponse = asyncClient.getObject(builder -> builder
+                .bucket(BUCKET)
+                .range("10-20")
+                .key(objectKey), AsyncResponseTransformer.toBytes()).join();
+        output = objectResponse.asUtf8String();
+        assertEquals(input, output);
+
+        // Invalid range starting index and ending index greater than object length but within Cipher Block size, returns empty object
+        objectResponse = asyncClient.getObject(builder -> builder
+                .bucket(BUCKET)
+                .range("bytes=216-217")
+                .key(objectKey), AsyncResponseTransformer.toBytes()).join();
+        output = objectResponse.asUtf8String();
+        assertEquals("", output);
 
         // Cleanup
         deleteObject(BUCKET, objectKey, asyncClient);


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Ranged get tests are failing intermittently in CI: 

```
Error:  Tests run: 9, Failures: 1, Errors: 0, Skipped: 0, Time elapsed: 6.782 s <<< FAILURE! - in software.amazon.encryption.s3.S3EncryptionClientRangedGetCompatibilityTest
Error:  AsyncAesGcmV3toV3RangedGet  Time elapsed: 0.466 s  <<< FAILURE!
org.opentest4j.AssertionFailedError: expected: <KLMNOPQRST> but was: <>
	at software.amazon.encryption.s3.S3EncryptionClientRangedGetCompatibilityTest.AsyncAesGcmV3toV3RangedGet(S3EncryptionClientRangedGetCompatibilityTest.java:80)
```



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
