### PR TITLE
chore: clean up some dead code and resolved TODOs

### DIFF
--- a/src/main/java/software/amazon/encryption/s3/S3AsyncEncryptionClient.java
+++ b/src/main/java/software/amazon/encryption/s3/S3AsyncEncryptionClient.java
@@ -42,7 +42,6 @@ public class S3AsyncEncryptionClient extends DelegatingS3AsyncClient {
     private final S3AsyncClient _wrappedClient;
     private final CryptographicMaterialsManager _cryptoMaterialsManager;
     private final SecureRandom _secureRandom;
-    private final boolean _enableLegacyWrappingAlgorithms;
     private final boolean _enableLegacyUnauthenticatedModes;
     private final boolean _enableDelayedAuthenticationMode;
 
@@ -51,7 +50,6 @@ public class S3AsyncEncryptionClient extends DelegatingS3AsyncClient {
         _wrappedClient = builder._wrappedClient;
         _cryptoMaterialsManager = builder._cryptoMaterialsManager;
         _secureRandom = builder._secureRandom;
-        _enableLegacyWrappingAlgorithms = builder._enableLegacyWrappingAlgorithms;
         _enableLegacyUnauthenticatedModes = builder._enableLegacyUnauthenticatedModes;
         _enableDelayedAuthenticationMode = builder._enableDelayedAuthenticationMode;
     }
@@ -84,7 +82,6 @@ public class S3AsyncEncryptionClient extends DelegatingS3AsyncClient {
         GetEncryptedObjectPipeline pipeline = GetEncryptedObjectPipeline.builder()
                 .s3AsyncClient(_wrappedClient)
                 .cryptoMaterialsManager(_cryptoMaterialsManager)
-                .enableLegacyWrappingAlgorithms(_enableLegacyWrappingAlgorithms)
                 .enableLegacyUnauthenticatedModes(_enableLegacyUnauthenticatedModes)
                 .enableDelayedAuthentication(_enableDelayedAuthenticationMode)
                 .build();

--- a/src/main/java/software/amazon/encryption/s3/S3EncryptionClient.java
+++ b/src/main/java/software/amazon/encryption/s3/S3EncryptionClient.java
@@ -82,7 +82,6 @@ public class S3EncryptionClient extends DelegatingS3Client {
     private final S3AsyncClient _wrappedAsyncClient;
     private final CryptographicMaterialsManager _cryptoMaterialsManager;
     private final SecureRandom _secureRandom;
-    private final boolean _enableLegacyWrappingAlgorithms;
     private final boolean _enableLegacyUnauthenticatedModes;
     private final boolean _enableDelayedAuthenticationMode;
     private final boolean _enableMultipartPutObject;
@@ -94,7 +93,6 @@ public class S3EncryptionClient extends DelegatingS3Client {
         _wrappedAsyncClient = builder._wrappedAsyncClient;
         _cryptoMaterialsManager = builder._cryptoMaterialsManager;
         _secureRandom = builder._secureRandom;
-        _enableLegacyWrappingAlgorithms = builder._enableLegacyWrappingAlgorithms;
         _enableLegacyUnauthenticatedModes = builder._enableLegacyUnauthenticatedModes;
         _enableDelayedAuthenticationMode = builder._enableDelayedAuthenticationMode;
         _enableMultipartPutObject = builder._enableMultipartPutObject;
@@ -158,7 +156,6 @@ public class S3EncryptionClient extends DelegatingS3Client {
         GetEncryptedObjectPipeline pipeline = GetEncryptedObjectPipeline.builder()
                 .s3AsyncClient(_wrappedAsyncClient)
                 .cryptoMaterialsManager(_cryptoMaterialsManager)
-                .enableLegacyWrappingAlgorithms(_enableLegacyWrappingAlgorithms)
                 .enableLegacyUnauthenticatedModes(_enableLegacyUnauthenticatedModes)
                 .enableDelayedAuthentication(_enableDelayedAuthenticationMode)
                 .build();
@@ -331,16 +328,6 @@ public class S3EncryptionClient extends DelegatingS3Client {
          */
         @SuppressFBWarnings(value = "EI_EXPOSE_REP2", justification = "Pass mutability into wrapping client")
         public Builder wrappedAsyncClient(S3AsyncClient _wrappedAsyncClient) {
-            if (_wrappedAsyncClient instanceof S3AsyncEncryptionClient) {
-                throw new S3EncryptionClientException("Cannot use S3EncryptionClient as wrapped client");
-            }
-
-            this._wrappedAsyncClient = _wrappedAsyncClient;
-            return this;
-        }
-
-        @SuppressFBWarnings(value = "EI_EXPOSE_REP2", justification = "Pass mutability into wrapping client")
-        public Builder _wrappedAsyncClient(S3AsyncClient _wrappedAsyncClient) {
             if (_wrappedAsyncClient instanceof S3AsyncEncryptionClient) {
                 throw new S3EncryptionClientException("Cannot use S3EncryptionClient as wrapped client");
             }

--- a/src/main/java/software/amazon/encryption/s3/internal/GetEncryptedObjectPipeline.java
+++ b/src/main/java/software/amazon/encryption/s3/internal/GetEncryptedObjectPipeline.java
@@ -35,10 +35,7 @@ import java.util.concurrent.CompletableFuture;
 public class GetEncryptedObjectPipeline {
     private final S3AsyncClient _s3AsyncClient;
     private final CryptographicMaterialsManager _cryptoMaterialsManager;
-    private final boolean _enableLegacyWrappingAlgorithms;
-
     private final boolean _enableLegacyUnauthenticatedModes;
-    // TODO: Find a way to use for async client
     private final boolean _enableDelayedAuthentication;
 
     public static Builder builder() {
@@ -48,7 +45,6 @@ public class GetEncryptedObjectPipeline {
     private GetEncryptedObjectPipeline(Builder builder) {
         this._s3AsyncClient = builder._s3AsyncClient;
         this._cryptoMaterialsManager = builder._cryptoMaterialsManager;
-        this._enableLegacyWrappingAlgorithms = builder._enableLegacyWrappingAlgorithms;
         this._enableLegacyUnauthenticatedModes = builder._enableLegacyUnauthenticatedModes;
         this._enableDelayedAuthentication = builder._enableDelayedAuthentication;
     }
@@ -172,7 +168,6 @@ public class GetEncryptedObjectPipeline {
     public static class Builder {
         private S3AsyncClient _s3AsyncClient;
         private CryptographicMaterialsManager _cryptoMaterialsManager;
-        private boolean _enableLegacyWrappingAlgorithms;
         private boolean _enableLegacyUnauthenticatedModes;
         private boolean _enableDelayedAuthentication;
 
@@ -191,11 +186,6 @@ public class GetEncryptedObjectPipeline {
 
         public Builder cryptoMaterialsManager(CryptographicMaterialsManager cryptoMaterialsManager) {
             this._cryptoMaterialsManager = cryptoMaterialsManager;
-            return this;
-        }
-
-        public Builder enableLegacyWrappingAlgorithms(boolean enableLegacyWrappingAlgorithms) {
-            this._enableLegacyWrappingAlgorithms = enableLegacyWrappingAlgorithms;
             return this;
         }
 

--- a/src/main/java/software/amazon/encryption/s3/internal/MultipartUploadObjectPipeline.java
+++ b/src/main/java/software/amazon/encryption/s3/internal/MultipartUploadObjectPipeline.java
@@ -58,7 +58,6 @@ public class MultipartUploadObjectPipeline {
                 .s3Request(request);
 
         EncryptionMaterials materials = _cryptoMaterialsManager.getEncryptionMaterials(requestBuilder.build());
-        // TODO: Look for Better design models
         EncryptedContent encryptedContent = _contentEncryptionStrategy.initMultipartEncryption(materials);
 
         Map<String, String> metadata = new HashMap<>(request.metadata());


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Mostly removes `enableLegacyWrappingAlgorithms` from the content (en/de)cryption pipelines, since it's only needed by the keyrings. Also removes some TODOs which are done or no longer relevant. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
