### PR TITLE
fix: set release version to Java 8 to ensure bytecode compatibility a…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -34,6 +34,7 @@
 
   <properties>
     <maven.compiler.source>8</maven.compiler.source>
+    <maven.compiler.target>8</maven.compiler.target>
     <maven.compiler.release>8</maven.compiler.release>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
   </properties>


### PR DESCRIPTION
…cross compiler versions

*Issue #, if available:*

*Description of changes:*

Refer to this blog post: https://www.morling.dev/blog/bytebuffer-and-the-dreaded-nosuchmethoderror/

This should prevent issues when compiling with a newer Java version and executing on an older version (e.g. Java 8).  

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
