### PR TITLE
fix: cast ByteBuffer to Buffer for Java 8 compatibility

### DIFF
--- a/src/main/java/software/amazon/encryption/s3/legacy/internal/AesCtrUtils.java
+++ b/src/main/java/software/amazon/encryption/s3/legacy/internal/AesCtrUtils.java
@@ -76,7 +76,9 @@ public class AesCtrUtils {
         if (val > MAX_GCM_BLOCKS) {
             throw new IllegalStateException(); // overflow 2^32-2
         }
-        bb.rewind();
+        // This cast is necessary to ensure compatibility with Java 1.8/8
+        // when compiling with a newer Java version than 8
+        ((java.nio.Buffer) bb).rewind();
         // Get the incremented value (result) as an 8-byte array
         byte[] result = bb.putLong(val).array();
         // Copy the rightmost 32 bits from the resultant array to the input counter;


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

See https://www.morling.dev/blog/bytebuffer-and-the-dreaded-nosuchmethoderror/ for context. 

In https://github.com/aws/aws-s3-encryption-client-java/pull/111 we added the flag to set the release to 8, but there have been reports that the `NoSuchMethodError` is still being thrown from a user on 1.8. 

Since we only have this problem in one place, I feel the cast fix is worth pursuing. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
