### PR TITLE
fix: update uploadPart request to use correct contentLength

### DIFF
--- a/src/test/java/software/amazon/encryption/s3/S3EncryptionClientMultipartUploadTest.java
+++ b/src/test/java/software/amazon/encryption/s3/S3EncryptionClientMultipartUploadTest.java
@@ -272,16 +272,18 @@ public class S3EncryptionClientMultipartUploadTest {
             partsSent++;
         }
 
+        final InputStream partInputStream = new ByteArrayInputStream(outputStream.toByteArray());
+
         // Last Part
         UploadPartRequest uploadPartRequest = UploadPartRequest.builder()
                 .bucket(BUCKET)
                 .key(objectKey)
                 .uploadId(initiateResult.uploadId())
                 .partNumber(partsSent)
+                .contentLength((long) partInputStream.available())
                 .sdkPartType(SdkPartType.LAST)
                 .build();
 
-        final InputStream partInputStream = new ByteArrayInputStream(outputStream.toByteArray());
         UploadPartResponse uploadPartResult = v3Client.uploadPart(uploadPartRequest,
                 RequestBody.fromInputStream(partInputStream, partInputStream.available()));
         partETags.add(CompletedPart.builder()


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

In https://github.com/aws/aws-s3-encryption-client-java/pull/115 we validated the contentLength of `uploadPart` requests but did not actually use it in the wrapped `uploadPart` request. This fixes that. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
