### PR TITLE
feat: add missing legacy v1 RSA key wrap mode

### DIFF
--- a/src/main/java/software/amazon/encryption/s3/internal/ContentMetadataStrategy.java
+++ b/src/main/java/software/amazon/encryption/s3/internal/ContentMetadataStrategy.java
@@ -129,8 +129,32 @@ public abstract class ContentMetadataStrategy implements ContentMetadataEncoding
                     throw new S3EncryptionClientException("Malformed object metadata! Could not find the encrypted data key.");
                 }
 
-                // Fall back on AES when wrap alg is missing to match V1 behavior
-                keyProviderInfo = metadata.getOrDefault(MetadataKeyConstants.ENCRYPTED_DATA_KEY_ALGORITHM, "AES");
+                if (!metadata.containsKey(MetadataKeyConstants.ENCRYPTED_DATA_KEY_ALGORITHM)) {
+                    /*
+                    For legacy v1 EncryptionOnly objects,
+                    there is no EDK algorithm given, it is either plain AES or RSA
+                    In v3, we infer AES vs. RSA based on the length of the ciphertext.
+
+                    In v1, whichever key material is provided in its EncryptionMaterials
+                    is used to decrypt the EDK.
+
+                    In v3, this is not possible as the keyring code is factored such that
+                    the keyProviderInfo is known before the keyring is known.
+                    Ciphertext size is expected to be reliable as no AES data key should
+                    exceed 256 bits (32 bytes) + 16 padding bytes.
+
+                    In the unlikely event that this assumption is false, the fix would be
+                    to refactor the keyring to always use the material given instead of
+                    inferring it this way.
+                    */
+                    if (edkCiphertext.length > 48) {
+                        keyProviderInfo = "RSA";
+                    } else {
+                        keyProviderInfo = "AES";
+                    }
+                } else {
+                    keyProviderInfo = metadata.get(MetadataKeyConstants.ENCRYPTED_DATA_KEY_ALGORITHM);
+                }
                 break;
             case ALG_AES_256_GCM_IV12_TAG16_NO_KDF:
             case ALG_AES_256_CTR_IV16_TAG16_NO_KDF:

--- a/src/main/java/software/amazon/encryption/s3/materials/S3Keyring.java
+++ b/src/main/java/software/amazon/encryption/s3/materials/S3Keyring.java
@@ -1,17 +1,15 @@
 package software.amazon.encryption.s3.materials;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import software.amazon.encryption.s3.S3EncryptionClientException;
 
+import javax.crypto.SecretKey;
 import java.nio.charset.StandardCharsets;
 import java.security.GeneralSecurityException;
 import java.security.SecureRandom;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
-
-import javax.crypto.SecretKey;
-
-import software.amazon.encryption.s3.S3EncryptionClientException;
 
 /**
  * This serves as the base class for all the keyrings in the S3 encryption client.
@@ -85,7 +83,7 @@ abstract public class S3Keyring implements Keyring {
 
         DecryptDataKeyStrategy decryptStrategy = decryptStrategies().get(keyProviderInfo);
         if (decryptStrategy == null) {
-            throw new S3EncryptionClientException("Unknown key wrap: " + keyProviderInfo);
+            throw new S3EncryptionClientException("The keyring does not support the object's key wrapping algorithm: " + keyProviderInfo);
         }
 
         if (decryptStrategy.isLegacy() && !_enableLegacyWrappingAlgorithms) {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

It is possible to use RSA keys as key wrapping keys in v1 in `EncryptionOnly` mode. The v3 client never supported this. This adds support and some testing for this legacy mode. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
