### PR TITLE
fix: factor out MultipartEncryptedContent to better model differences…

### DIFF
--- a/src/main/java/software/amazon/encryption/s3/internal/EncryptedContent.java
+++ b/src/main/java/software/amazon/encryption/s3/internal/EncryptedContent.java
@@ -2,18 +2,11 @@ package software.amazon.encryption.s3.internal;
 
 import software.amazon.awssdk.core.async.AsyncRequestBody;
 
-import javax.crypto.Cipher;
-import java.io.InputStream;
-
 public class EncryptedContent {
 
-    private InputStream _ciphertext;
     private AsyncRequestBody _encryptedRequestBody;
     private long _ciphertextLength = -1;
-    private byte[] _iv;
-
-    // TODO: Look for Better ways to handle Cipher for Multipart Uploads.
-    private Cipher _cipher;
+    protected byte[] _iv;
 
     public EncryptedContent(final byte[] iv, final AsyncRequestBody encryptedRequestBody, final long ciphertextLength) {
         _iv = iv;
@@ -21,21 +14,8 @@ public class EncryptedContent {
         _ciphertextLength = ciphertextLength;
     }
 
-    public EncryptedContent(final byte[] iv, Cipher cipher) {
-        this._iv = iv;
-        this._cipher = cipher;
-    }
-
-    public Cipher getCipher() {
-        return _cipher;
-    }
-
     public byte[] getIv() {
         return _iv;
-    }
-
-    public InputStream getCiphertext() {
-        return _ciphertext;
     }
 
     public long getCiphertextLength() {

--- a/src/main/java/software/amazon/encryption/s3/internal/MultipartContentEncryptionStrategy.java
+++ b/src/main/java/software/amazon/encryption/s3/internal/MultipartContentEncryptionStrategy.java
@@ -4,5 +4,5 @@ import software.amazon.encryption.s3.materials.EncryptionMaterials;
 
 @FunctionalInterface
 public interface MultipartContentEncryptionStrategy {
-    EncryptedContent initMultipartEncryption(EncryptionMaterials materials);
+    MultipartEncryptedContent initMultipartEncryption(EncryptionMaterials materials);
 }

--- a/src/main/java/software/amazon/encryption/s3/internal/MultipartEncryptedContent.java
+++ b/src/main/java/software/amazon/encryption/s3/internal/MultipartEncryptedContent.java
@@ -1,0 +1,32 @@
+package software.amazon.encryption.s3.internal;
+
+import software.amazon.awssdk.core.async.AsyncRequestBody;
+
+import javax.crypto.Cipher;
+
+public class MultipartEncryptedContent extends EncryptedContent {
+    private final Cipher _cipher;
+
+    public MultipartEncryptedContent(byte[] iv, Cipher cipher, long ciphertextLength) {
+        super(iv, null, ciphertextLength);
+        _cipher = cipher;
+        _iv = iv;
+    }
+
+    /**
+     * MultipartEncryptedContent cannot store a ciphertext AsyncRequestBody
+     * as it one is generated for each part using the cipher in this class.
+     * @throws UnsupportedOperationException always
+     */
+    @Override
+    public AsyncRequestBody getAsyncCiphertext() {
+        throw new UnsupportedOperationException("MultipartEncryptedContent does not support async ciphertext!");
+    }
+
+    /**
+     * @return the cipher used for the duration of the multipart upload
+     */
+    public Cipher getCipher() {
+        return _cipher;
+    }
+}

--- a/src/main/java/software/amazon/encryption/s3/internal/MultipartUploadObjectPipeline.java
+++ b/src/main/java/software/amazon/encryption/s3/internal/MultipartUploadObjectPipeline.java
@@ -59,7 +59,7 @@ public class MultipartUploadObjectPipeline {
                 .s3Request(request);
 
         EncryptionMaterials materials = _cryptoMaterialsManager.getEncryptionMaterials(requestBuilder.build());
-        EncryptedContent encryptedContent = _contentEncryptionStrategy.initMultipartEncryption(materials);
+        MultipartEncryptedContent encryptedContent = _contentEncryptionStrategy.initMultipartEncryption(materials);
 
         Map<String, String> metadata = new HashMap<>(request.metadata());
         metadata = _contentMetadataEncodingStrategy.encodeMetadata(materials, encryptedContent.getIv(), metadata);

--- a/src/main/java/software/amazon/encryption/s3/internal/StreamingAesGcmContentStrategy.java
+++ b/src/main/java/software/amazon/encryption/s3/internal/StreamingAesGcmContentStrategy.java
@@ -22,7 +22,7 @@ public class StreamingAesGcmContentStrategy implements AsyncContentEncryptionStr
     }
 
     @Override
-    public EncryptedContent initMultipartEncryption(EncryptionMaterials materials) {
+    public MultipartEncryptedContent initMultipartEncryption(EncryptionMaterials materials) {
         if (materials.getPlaintextLength() > AlgorithmSuite.ALG_AES_256_GCM_IV12_TAG16_NO_KDF.cipherMaxContentLengthBytes()) {
             throw new S3EncryptionClientException("The contentLength of the object you are attempting to encrypt exceeds" +
                     "the maximum length allowed for GCM encryption.");
@@ -32,7 +32,7 @@ public class StreamingAesGcmContentStrategy implements AsyncContentEncryptionStr
         _secureRandom.nextBytes(iv);
 
         final Cipher cipher = CipherProvider.createAndInitCipher(materials, iv);
-        return new EncryptedContent(iv, cipher);
+        return new MultipartEncryptedContent(iv, cipher, materials.getCiphertextLength());
     }
 
     @Override


### PR DESCRIPTION
… in multipart encrypt

*Issue #, if available:*

*Description of changes:* 

The `EncryptedContent` class was being used for both ordinary encryption and multipart encryption but without clear separation of responsibility. This factors things out a bit more cleanly. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
