### PR TITLE
chore: add user agent to all wrapped requests

### DIFF
--- a/src/main/java/software/amazon/encryption/s3/internal/ApiNameVersion.java
+++ b/src/main/java/software/amazon/encryption/s3/internal/ApiNameVersion.java
@@ -1,22 +1,28 @@
 package software.amazon.encryption.s3.internal;
 
 
+import software.amazon.awssdk.awscore.AwsRequestOverrideConfiguration;
 import software.amazon.awssdk.core.ApiName;
 
 import java.io.IOException;
 import java.util.Properties;
+import java.util.function.Consumer;
 
 /**
  * Provides the information for the ApiName APIs for the AWS SDK
  */
 public class ApiNameVersion {
-    public static final String API_NAME = "AmazonS3Encrypt";
+    private static final ApiName API_NAME = ApiNameVersion.apiNameWithVersion();
+    // This is used in overrideConfiguration
+    public static final Consumer<AwsRequestOverrideConfiguration.Builder> API_NAME_INTERCEPTOR =
+            builder -> builder.addApiName(API_NAME);
 
+    public static final String NAME = "AmazonS3Encrypt";
     public static final String API_VERSION_UNKNOWN = "3-unknown";
 
     public static ApiName apiNameWithVersion() {
         return ApiName.builder()
-                .name(API_NAME)
+                .name(NAME)
                 .version(apiVersion())
                 .build();
     }

--- a/src/main/java/software/amazon/encryption/s3/internal/GetEncryptedObjectPipeline.java
+++ b/src/main/java/software/amazon/encryption/s3/internal/GetEncryptedObjectPipeline.java
@@ -25,6 +25,8 @@ import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 
+import static software.amazon.encryption.s3.internal.ApiNameVersion.API_NAME_INTERCEPTOR;
+
 /**
  * This class will determine the necessary mechanisms to decrypt objects returned from S3.
  * Due to supporting various legacy modes, this is not a predefined pipeline like
@@ -51,7 +53,10 @@ public class GetEncryptedObjectPipeline {
     public <T> CompletableFuture<T> getObject(GetObjectRequest getObjectRequest, AsyncResponseTransformer<GetObjectResponse, T> asyncResponseTransformer) {
         // In async, decryption is done within a response transformation
         String cryptoRange = RangedGetUtils.getCryptoRangeAsString(getObjectRequest.range());
-        GetObjectRequest adjustedRangeRequest = getObjectRequest.toBuilder().range(cryptoRange).build();
+        GetObjectRequest adjustedRangeRequest = getObjectRequest.toBuilder()
+                .overrideConfiguration(API_NAME_INTERCEPTOR)
+                .range(cryptoRange)
+                .build();
         if (!_enableLegacyUnauthenticatedModes && getObjectRequest.range() != null) {
             throw new S3EncryptionClientException("Enable legacy unauthenticated modes to use Ranged Get.");
         }

--- a/src/main/java/software/amazon/encryption/s3/internal/PutEncryptedObjectPipeline.java
+++ b/src/main/java/software/amazon/encryption/s3/internal/PutEncryptedObjectPipeline.java
@@ -15,6 +15,8 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 
+import static software.amazon.encryption.s3.internal.ApiNameVersion.API_NAME_INTERCEPTOR;
+
 public class PutEncryptedObjectPipeline {
 
     final private S3AsyncClient _s3AsyncClient;
@@ -63,6 +65,7 @@ public class PutEncryptedObjectPipeline {
         Map<String, String> metadata = new HashMap<>(request.metadata());
         metadata = _contentMetadataEncodingStrategy.encodeMetadata(materials, encryptedContent.getIv(), metadata);
         PutObjectRequest encryptedPutRequest = request.toBuilder()
+                .overrideConfiguration(API_NAME_INTERCEPTOR)
                 .contentLength(encryptedContent.getCiphertextLength())
                 .metadata(metadata)
                 .build();


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

To have telemetry, the user agent must be set specific to S3 Encryption Client. In SDKv2, this is done using `overrideConfiguration`. For reference, the AWS Encryption SDK does [the same thing](https://github.com/aws/aws-encryption-sdk-java/blob/006cdc4b6395536c8c1b317d85c252f4892d6172/src/main/java/com/amazonaws/encryptionsdk/kmssdkv2/KmsMasterKey.java#L48). 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
