### PR TITLE
fix: remove redundant retry/reinit logic

### DIFF
--- a/src/main/java/software/amazon/encryption/s3/internal/CipherSubscriber.java
+++ b/src/main/java/software/amazon/encryption/s3/internal/CipherSubscriber.java
@@ -47,16 +47,7 @@ public class CipherSubscriber implements Subscriber<ByteBuffer> {
 
         if (amountToReadFromByteBuffer > 0) {
             byte[] buf = BinaryUtils.copyBytesFrom(byteBuffer, amountToReadFromByteBuffer);
-            try {
-                outputBuffer = cipher.update(buf, 0, amountToReadFromByteBuffer);
-            } catch (final IllegalStateException exception) {
-                // This happens when the stream is reset and the cipher is reused with the
-                // same key/IV. It's actually fine here, because the data is the same, but any
-                // sane implementation will throw an exception.
-                // Request a new cipher using the same materials to avoid reinit issues
-                // TODO: This can probably be moved into CipherAsyncRequestBody
-                cipher = CipherProvider.createAndInitCipher(materials, iv);
-            }
+            outputBuffer = cipher.update(buf, 0, amountToReadFromByteBuffer);
             if (outputBuffer == null && amountToReadFromByteBuffer < cipher.getBlockSize()) {
                 // The underlying data is too short to fill in the block cipher
                 // This is true at the end of the file, so complete to get the final


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

In `materials.getCipher(iv)` the cipher is re-init'd, so re-instantiating the `CipherSubscriber` should be sufficient to refresh the cipher on retry.  

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
