### PR TITLE
fix: make multipartPutObject in S3AsyncEncryptionClient private

### DIFF
--- a/src/main/java/software/amazon/encryption/s3/S3AsyncEncryptionClient.java
+++ b/src/main/java/software/amazon/encryption/s3/S3AsyncEncryptionClient.java
@@ -87,7 +87,7 @@ public class S3AsyncEncryptionClient extends DelegatingS3AsyncClient {
         return pipeline.putObject(putObjectRequest, requestBody);
     }
 
-    public CompletableFuture<PutObjectResponse> multipartPutObject(PutObjectRequest putObjectRequest, AsyncRequestBody requestBody) {
+    private CompletableFuture<PutObjectResponse> multipartPutObject(PutObjectRequest putObjectRequest, AsyncRequestBody requestBody) {
         S3AsyncClient crtClient;
         if (_wrappedClient instanceof S3CrtAsyncClient) {
             // if the wrappedClient is a CRT, use it


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

This method should NOT be public, this PR makes it private. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
