### PR TITLE
chore: add prod release workflow

### DIFF
--- a/codebuild/release/artifact-hunt.yml
+++ b/codebuild/release/artifact-hunt.yml
@@ -1,0 +1,20 @@
+## Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+## SPDX-License-Identifier: Apache-2.0
+
+version: 0.2
+
+env:
+  variables:
+    BRANCH: "main"
+
+phases:
+  install:
+    runtime-versions:
+      java: corretto11
+  pre_build:
+    commands:
+      - git checkout $BRANCH
+      - export VERSION=$(grep version pom.xml | head -n 1 | sed -n 's/[ \t]*<version>\(.*\)<\/version>/\1/p')
+  build:
+    commands:
+      - ./look_4_version.sh $VERSION

--- a/codebuild/release/release-prod.yml
+++ b/codebuild/release/release-prod.yml
@@ -1,0 +1,39 @@
+
+## Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+## SPDX-License-Identifier: Apache-2.0
+
+version: 0.2
+
+env:
+  variables:
+    BRANCH: "main"
+  secrets-manager:
+    GPG_KEY: Maven-GPG-Keys-Release-Credentials:Keyname
+    GPG_PASS: Maven-GPG-Keys-Release-Credentials:Passphrase
+    SONA_USERNAME: Sonatype-Team-Account:Username 
+    SONA_PASSWORD: Sonatype-Team-Account:Password
+
+phases:
+  install:
+    runtime-versions:
+      java: corretto11
+  pre_build:
+    commands:
+      - git checkout $BRANCH
+      - export SETTINGS_FILE=$(pwd)/codebuild/release/settings.xml
+      - aws secretsmanager get-secret-value --region us-west-2 --secret-id Maven-GPG-Keys-Release --query SecretBinary --output text | base64 -d > ~/mvn_gpg.tgz
+      - tar -xvf ~/mvn_gpg.tgz -C ~
+  build:
+    commands:
+      - |
+        mvn deploy \
+          -Ppublishing \
+          -DperformRelease \
+          -Dgpg.homedir="$HOME/mvn_gpg" \
+          -DautoReleaseAfterClose=true \
+          -Dgpg.keyname="$GPG_KEY" \
+          -Dgpg.passphrase="$GPG_PASS" \
+          -Dsonatype.username="$SONA_USERNAME" \
+          -Dsonatype.password="$SONA_PASSWORD" \
+          --no-transfer-progress \
+          -s $SETTINGS_FILE

--- a/codebuild/release/release.yml
+++ b/codebuild/release/release.yml
@@ -69,21 +69,30 @@ batch:
       - validate_staging_release_corretto17
     buildspec: codebuild/release/version.yml
     env:
-      image: aws/codebuild/standard:5.0
+      image: aws/codebuild/standard:6.0
 
-  # TODO for prod release: Release to Maven
+  # Publish to Maven Central
+  - identifier: publish
+    depend-on:
+      - version
+    buildspec: codebuild/release/release-prod.yml
 
-  # TODO for prod release: Validate Maven release
+  # TODO: Validate Maven artifact using a sample project
+
+  # Search for published Artifact
+  - identifier: artifact_hunt
+    depend-on:
+      - publish
+    buildspec: codebuild/release/artifact-hunt.yml
 
   # Upload Artifacts
   - identifier: upload_artifacts
     depend-on:
-      # TODO for prod release: depend-on Maven release validations, not 'version' step
-      - version
+      - artifact_hunt
     buildspec: codebuild/release/upload_artifacts.yml
     env:
-      # standard:5.0 (Ubuntu) supports GH CLI; AL2 does not
-      image: aws/codebuild/standard:5.0
+      # standard:6.0 (Ubuntu) supports GH CLI; AL2 does not
+      image: aws/codebuild/standard:6.0
 
   # Generate and update new javadocs
   - identifier: update_javadoc

--- a/codebuild/release/upload_artifacts.yml
+++ b/codebuild/release/upload_artifacts.yml
@@ -6,11 +6,6 @@ version: 0.2
 env:
   variables:
     BRANCH: "main"
-    # TODO for prod release: Remove variables below; these are used in CodeArtifact, which won't be
-    #   used as part of Prod release. These are used to test GH release signing.
-    REGION: us-east-1
-    DOMAIN: crypto-tools-internal
-    REPOSITORY: java-s3ec-staging
   git-credential-helper: yes
   parameter-store:
     ACCOUNT: /CodeBuild/AccountId
@@ -20,10 +15,6 @@ env:
 phases:
   pre_build:
     commands:
-      # TODO for prod release: remove codeartifact authoriztion
-      # get codeartifact authorization
-      - export SETTINGS_FILE=$(pwd)/codebuild/release/settings.xml
-      - export CODEARTIFACT_AUTH_TOKEN=$(aws codeartifact get-authorization-token --domain $DOMAIN --domain-owner $ACCOUNT --query authorizationToken --output text --region ${REGION})
       # get new project version
       - git checkout $BRANCH
       - export VERSION=$(grep version pom.xml | head -n 2 | sed -n 's/[ \t]*<version>\(.*\)<\/version>/\1/p')
@@ -41,31 +32,16 @@ phases:
       - gh version
       - gh auth login --with-token < token.txt
       - gh auth status
-      # TODO for prod release: remove -Dcodeartifact*
-      # TODO for prod release: Change -DremoteRepositories to sonatype repo
-      # TODO for prod release: remove "-$CODEBUILD_RESOLVED_SOURCE_VERSION". CodeArtifact seems to need this to find
-      #   the artifact, but sonatype doesn't. I don't think it's worth finding a way to get artifact without version
-      #   hash given prod release doesn't need this.
-      # TODO for prod release: remove -s $SETTINGS_FILE
       - |
         mvn org.apache.maven.plugins:maven-dependency-plugin:3.1.2:get \
-          -Dcodeartifact.token=$CODEARTIFACT_AUTH_TOKEN \
-          -Dcodeartifact.url=https://${DOMAIN}-${ACCOUNT}.d.codeartifact.${REGION}.amazonaws.com/maven/${REPOSITORY} \
-          -DremoteRepositories=central::default::https://repo.maven.apache.org/maven2,codeartifact::::https://${DOMAIN}-${ACCOUNT}.d.codeartifact.${REGION}.amazonaws.com/maven/${REPOSITORY} \
-          -Dartifact=software.amazon.encryption:s3:${VERSION}-$CODEBUILD_RESOLVED_SOURCE_VERSION:jar \
-          -s $SETTINGS_FILE
+          -DrepoUrl=https://aws.oss.sonatype.org \
+          -Dartifact=software.amazon.encryption:amazon-s3-encryption-client-java:${VERSION}:jar
       - |
         mvn org.apache.maven.plugins:maven-dependency-plugin:3.1.2:get \
-          -Dcodeartifact.token=$CODEARTIFACT_AUTH_TOKEN \
-          -Dcodeartifact.url=https://${DOMAIN}-${ACCOUNT}.d.codeartifact.${REGION}.amazonaws.com/maven/${REPOSITORY} \
-          -DremoteRepositories=central::default::https://repo.maven.apache.org/maven2,codeartifact::::https://${DOMAIN}-${ACCOUNT}.d.codeartifact.${REGION}.amazonaws.com/maven/${REPOSITORY} \
-          -Dartifact=software.amazon.encryption:s3:${VERSION}-$CODEBUILD_RESOLVED_SOURCE_VERSION:jar:sources \
-          -s $SETTINGS_FILE
+          -DrepoUrl=https://aws.oss.sonatype.org \
+          -Dartifact=software.amazon.encryption:amazon-s3-encryption-client-java:${VERSION}:jar:sources
       - |
         mvn org.apache.maven.plugins:maven-dependency-plugin:3.1.2:get \
-          -Dcodeartifact.token=$CODEARTIFACT_AUTH_TOKEN \
-          -Dcodeartifact.url=https://${DOMAIN}-${ACCOUNT}.d.codeartifact.${REGION}.amazonaws.com/maven/${REPOSITORY} \
-          -DremoteRepositories=central::default::https://repo.maven.apache.org/maven2,codeartifact::::https://${DOMAIN}-${ACCOUNT}.d.codeartifact.${REGION}.amazonaws.com/maven/${REPOSITORY} \
-          -Dartifact=software.amazon.encryption:s3:${VERSION}-$CODEBUILD_RESOLVED_SOURCE_VERSION:jar:javadoc \
-          -s $SETTINGS_FILE
-      - gh release create v${VERSION} ~/.m2/repository/software/amazon/encryption/s3/${VERSION}-$CODEBUILD_RESOLVED_SOURCE_VERSION/*.jar -d -F CHANGELOG.md -t "Amazon S3 Encryption Client ${VERSION} Release -- $(date +%Y-%m-%d)"
+          -DrepoUrl=https://aws.oss.sonatype.org \
+          -Dartifact=software.amazon.encryption:amazon-s3-encryption-client-java:${VERSION}:jar:javadoc
+      - gh release create v${VERSION} ~/.m2/repository/software/amazon/encryption/amazon-s3-encryption-client-java/${VERSION}/*.jar -d -F CHANGELOG.md -t "Amazon S3 Encryption Client ${VERSION} Release -- $(date +%Y-%m-%d)"

--- a/codebuild/release/version.yml
+++ b/codebuild/release/version.yml
@@ -14,13 +14,14 @@ env:
 phases:
   install:
     commands:
+      - n 18 # semantic-release wants 18, the image only goes up to 16
       - npm install --save-dev semantic-release
       - npm install @semantic-release/changelog -d
       - npm install @semantic-release/exec -d
       - npm install @semantic-release/git -d
       - npm install --save conventional-changelog
     runtime-versions:
-      nodejs: 18
+      nodejs: 16
   pre_build:
     commands:
       - git config --global user.name "aws-crypto-tools-ci-bot"

--- a/look_4_version.sh
+++ b/look_4_version.sh
@@ -1,0 +1,29 @@
+## Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+## SPDX-License-Identifier: Apache-2.0
+
+#!bin/bash
+
+VERSION=$1
+COUNTER=0
+STATUS=1
+
+echo "Looking for version $VERSION"
+
+while [  $STATUS -ne 0 ]; do
+    mvn org.apache.maven.plugins:maven-dependency-plugin:3.0.1:get \
+        -Dartifact=software.amazon.encryption.s3:amazon-s3-encryption-client-java:$VERSION:jar -U
+
+    STATUS=$?
+    if [ $STATUS -eq 0 ]; then
+        echo "Found version $VERSION in Maven Central :)"
+        break
+    fi
+
+    if [  $((COUNTER+=1)) -eq 15 ]; then
+        echo "It has been an awfully long time, you should check Maven Central for issues"
+        exit 1
+    fi
+
+    echo "Could not find version $VERSION. Trying again."
+    sleep 60
+done

--- a/pom.xml
+++ b/pom.xml
@@ -252,24 +252,13 @@
   <profiles>
     <profile>
       <id>publishingCodeArtifact</id>
-
-      <distributionManagement>
-        <!--
-        Registers an alternate repository for testing the publishing process using CodeArtifact
-        before moving to the production sonatype repository.
-
-        This can be used with a mvn invocation like:
-
-        mvn deploy -PpublishingCodeArtifact \
-                   -DaltDeploymentRepository=codeartifact::default::$CODEARTIFACT_REPO_URL \
-                   ...
-        -->
-        <repository>
-          <id>codeartifact</id>
-          <name>codeartifact</name>
-          <!-- url specified using -DaltDeploymentRepository to avoid hardcoding it here -->
-        </repository>
-      </distributionManagement>
+        <distributionManagement>
+          <repository>
+            <id>codeartifact</id>
+            <name>codeartifact</name>
+            <!-- url specified using -DaltDeploymentRepository to avoid hardcoding it here -->
+          </repository>
+        </distributionManagement>
 
       <build>
         <plugins>
@@ -296,8 +285,51 @@
         </plugins>
       </build>
     </profile>
+
+    <profile>
+      <id>publishing</id>
+
+      <distributionManagement>
+        <snapshotRepository>
+          <id>sonatype-nexus-staging</id>
+          <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+        </snapshotRepository>
+      </distributionManagement>
+
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-gpg-plugin</artifactId>
+            <version>3.0.1</version>
+            <executions>
+              <execution>
+                <id>sign-artifacts</id>
+                <phase>verify</phase>
+                <goals>
+                  <goal>sign</goal>
+                </goals>
+                <configuration>
+                  <gpgArguments>
+                    <arg>--pinentry-mode</arg>
+                    <arg>loopback</arg>
+                  </gpgArguments>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+          <plugin>
+            <groupId>org.sonatype.plugins</groupId>
+            <artifactId>nexus-staging-maven-plugin</artifactId>
+            <version>1.6.13</version>
+            <extensions>true</extensions>
+            <configuration>
+              <serverId>sonatype-nexus-staging</serverId>
+                <nexusUrl>https://aws.oss.sonatype.org</nexusUrl>
+            </configuration>
+           </plugin>
+        </plugins>
+      </build>
+    </profile>
   </profiles>
-
-
-
 </project>


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Adds prod (Maven) release workflow. Mostly the same as ESDK Java with some minor differences. Namely, there isn't a sample project like the ESDK's Busy Engineers Guide to verify the Maven artifact with.  

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
