### PR TITLE
fix: remove illegal javadoc tags

### DIFF
--- a/src/main/java/software/amazon/encryption/s3/S3AsyncEncryptionClient.java
+++ b/src/main/java/software/amazon/encryption/s3/S3AsyncEncryptionClient.java
@@ -112,7 +112,6 @@ public class S3AsyncEncryptionClient extends DelegatingS3AsyncClient {
      *         credentials, etc.</li>
      *         <li>S3EncryptionClientException Base class for all encryption client specific exceptions.</li>
      *         </ul>
-     *         </p>
      */
     @Override
     public CompletableFuture<PutObjectResponse> putObject(PutObjectRequest putObjectRequest, AsyncRequestBody requestBody)
@@ -173,7 +172,6 @@ public class S3AsyncEncryptionClient extends DelegatingS3AsyncClient {
      *         credentials, etc.</li>
      *         <li>S3EncryptionClientException Base class for all encryption client exceptions.</li>
      *         </ul>
-     *         </p>
      */
     @Override
     public <T> CompletableFuture<T> getObject(GetObjectRequest getObjectRequest,


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Removes illegally used `</p>` tags. They're allowed elsewhere but are apparently illegal in their former usage. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

# Check any applicable:
- [ ] Were any files moved? Moving files changes their URL, which breaks all hyperlinks to the files.
