### PR TITLE
fix: null check for InputStream in ApiNameVersion

### DIFF
--- a/src/main/java/software/amazon/encryption/s3/internal/ApiNameVersion.java
+++ b/src/main/java/software/amazon/encryption/s3/internal/ApiNameVersion.java
@@ -36,8 +36,8 @@ public class ApiNameVersion {
             final ClassLoader loader = ApiNameVersion.class.getClassLoader();
 
             final InputStream inputStream = loader.getResourceAsStream("project.properties");
-            // In some cases, e.g. native images, there is no way to load files
-            // and the inputStream returned is null
+            // In some cases, e.g. native images, there is no way to load files,
+            // and the inputStream returned is null.
             if (inputStream == null) {
                 return API_VERSION_UNKNOWN;
             }

--- a/src/main/java/software/amazon/encryption/s3/internal/ApiNameVersion.java
+++ b/src/main/java/software/amazon/encryption/s3/internal/ApiNameVersion.java
@@ -7,6 +7,7 @@ import software.amazon.awssdk.awscore.AwsRequestOverrideConfiguration;
 import software.amazon.awssdk.core.ApiName;
 
 import java.io.IOException;
+import java.io.InputStream;
 import java.util.Properties;
 import java.util.function.Consumer;
 
@@ -33,7 +34,15 @@ public class ApiNameVersion {
         try {
             final Properties properties = new Properties();
             final ClassLoader loader = ApiNameVersion.class.getClassLoader();
-            properties.load(loader.getResourceAsStream("project.properties"));
+
+            final InputStream inputStream = loader.getResourceAsStream("project.properties");
+            // In some cases, e.g. native images, there is no way to load files
+            // and the inputStream returned is null
+            if (inputStream == null) {
+                return API_VERSION_UNKNOWN;
+            }
+
+            properties.load(inputStream);
             return properties.getProperty("version");
         } catch (final IOException ex) {
             return API_VERSION_UNKNOWN;


### PR DESCRIPTION
*Issue #, if available:* https://github.com/aws/amazon-s3-encryption-client-java/issues/158

*Description of changes:*

In response to https://github.com/aws/amazon-s3-encryption-client-java/issues/158, check if the `InputStream` instance is `null` to avoid the ensuing NPE in `properties.load()` when it is.  

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

# Check any applicable:
- [ ] Were any files moved? Moving files changes their URL, which breaks all hyperlinks to the files.
