### PR TITLE
fix: unwrap CompletionException in default client, rethrow as S3Encry…

### DIFF
--- a/src/main/java/software/amazon/encryption/s3/S3EncryptionClient.java
+++ b/src/main/java/software/amazon/encryption/s3/S3EncryptionClient.java
@@ -187,8 +187,15 @@ public class S3EncryptionClient extends DelegatingS3Client {
                 .secureRandom(_secureRandom)
                 .build();
 
-        CompletableFuture<PutObjectResponse> futurePut = pipeline.putObject(putObjectRequest, AsyncRequestBody.fromInputStream(requestBody.contentStreamProvider().newStream(), requestBody.optionalContentLength().orElse(-1L), Executors.newSingleThreadExecutor()));
-        return futurePut.join();
+        try {
+            CompletableFuture<PutObjectResponse> futurePut = pipeline.putObject(putObjectRequest, AsyncRequestBody.fromInputStream(requestBody.contentStreamProvider().newStream(), requestBody.optionalContentLength().orElse(-1L), Executors.newSingleThreadExecutor()));
+            return futurePut.join();
+        } catch (CompletionException completionException) {
+            throw new S3EncryptionClientException(completionException.getMessage(), completionException.getCause());
+        } catch (Exception exception) {
+            throw new S3EncryptionClientException(exception.getMessage(), exception);
+        }
+
     }
 
     /**
@@ -311,7 +318,7 @@ public class S3EncryptionClient extends DelegatingS3Client {
 
     private <T extends Throwable> T onAbort(UploadObjectObserver observer, T t) {
         observer.onAbort();
-        return t;
+        throw new S3EncryptionClientException(t.getMessage(), t);
     }
 
     /**
@@ -329,15 +336,23 @@ public class S3EncryptionClient extends DelegatingS3Client {
         DeleteObjectRequest actualRequest = deleteObjectRequest.toBuilder()
                 .overrideConfiguration(API_NAME_INTERCEPTOR)
                 .build();
-        // Delete the object
-        DeleteObjectResponse deleteObjectResponse = _wrappedAsyncClient.deleteObject(actualRequest).join();
-        // If Instruction file exists, delete the instruction file as well.
-        String instructionObjectKey = deleteObjectRequest.key() + INSTRUCTION_FILE_SUFFIX;
-        _wrappedAsyncClient.deleteObject(builder -> builder
-                .overrideConfiguration(API_NAME_INTERCEPTOR)
-                .bucket(deleteObjectRequest.bucket())
-                .key(instructionObjectKey)).join();
-        return deleteObjectResponse;
+
+        try {
+            // Delete the object
+            DeleteObjectResponse deleteObjectResponse = _wrappedAsyncClient.deleteObject(actualRequest).join();
+            // If Instruction file exists, delete the instruction file as well.
+            String instructionObjectKey = deleteObjectRequest.key() + INSTRUCTION_FILE_SUFFIX;
+            _wrappedAsyncClient.deleteObject(builder -> builder
+                    .overrideConfiguration(API_NAME_INTERCEPTOR)
+                    .bucket(deleteObjectRequest.bucket())
+                    .key(instructionObjectKey)).join();
+            // Return original deletion
+            return deleteObjectResponse;
+        } catch (CompletionException e) {
+            throw new S3EncryptionClientException(e.getCause().getMessage(), e.getCause());
+        } catch (Exception e) {
+            throw new S3EncryptionClientException("Unable to delete object.", e);
+        }
     }
 
     /**
@@ -355,16 +370,22 @@ public class S3EncryptionClient extends DelegatingS3Client {
         DeleteObjectsRequest actualRequest = deleteObjectsRequest.toBuilder()
                 .overrideConfiguration(API_NAME_INTERCEPTOR)
                 .build();
-        // Delete the objects
-        DeleteObjectsResponse deleteObjectsResponse = _wrappedAsyncClient.deleteObjects(actualRequest).join();
-        // If Instruction files exists, delete the instruction files as well.
-        List<ObjectIdentifier> deleteObjects = instructionFileKeysToDelete(deleteObjectsRequest);
-        _wrappedAsyncClient.deleteObjects(DeleteObjectsRequest.builder()
-                .overrideConfiguration(API_NAME_INTERCEPTOR)
-                .bucket(deleteObjectsRequest.bucket())
-                .delete(builder -> builder.objects(deleteObjects))
-                .build()).join();
-        return deleteObjectsResponse;
+        try {
+            // Delete the objects
+            DeleteObjectsResponse deleteObjectsResponse = _wrappedAsyncClient.deleteObjects(actualRequest).join();
+            // If Instruction files exists, delete the instruction files as well.
+            List<ObjectIdentifier> deleteObjects = instructionFileKeysToDelete(deleteObjectsRequest);
+            _wrappedAsyncClient.deleteObjects(DeleteObjectsRequest.builder()
+                    .overrideConfiguration(API_NAME_INTERCEPTOR)
+                    .bucket(deleteObjectsRequest.bucket())
+                    .delete(builder -> builder.objects(deleteObjects))
+                    .build()).join();
+            return deleteObjectsResponse;
+        } catch (CompletionException e) {
+            throw new S3EncryptionClientException(e.getCause().getMessage(), e.getCause());
+        } catch (Exception e) {
+            throw new S3EncryptionClientException("Unable to delete objects.", e);
+        }
     }
 
     /**
@@ -379,7 +400,13 @@ public class S3EncryptionClient extends DelegatingS3Client {
      */
     @Override
     public CreateMultipartUploadResponse createMultipartUpload(CreateMultipartUploadRequest request) {
-        return _multipartPipeline.createMultipartUpload(request);
+        try {
+            return _multipartPipeline.createMultipartUpload(request);
+        } catch (CompletionException e) {
+            throw new S3EncryptionClientException(e.getCause().getMessage(), e.getCause());
+        } catch (Exception e) {
+            throw new S3EncryptionClientException("Unable to delete objects.", e);
+        }
     }
 
     /**
@@ -396,7 +423,13 @@ public class S3EncryptionClient extends DelegatingS3Client {
     @Override
     public UploadPartResponse uploadPart(UploadPartRequest request, RequestBody requestBody)
             throws AwsServiceException, SdkClientException {
-        return _multipartPipeline.uploadPart(request, requestBody);
+        try {
+            return _multipartPipeline.uploadPart(request, requestBody);
+        } catch (CompletionException e) {
+            throw new S3EncryptionClientException(e.getCause().getMessage(), e.getCause());
+        } catch (Exception e) {
+            throw new S3EncryptionClientException("Unable to delete objects.", e);
+        }
     }
 
     /**
@@ -407,7 +440,13 @@ public class S3EncryptionClient extends DelegatingS3Client {
     @Override
     public CompleteMultipartUploadResponse completeMultipartUpload(CompleteMultipartUploadRequest request)
             throws AwsServiceException, SdkClientException {
-        return _multipartPipeline.completeMultipartUpload(request);
+        try {
+            return _multipartPipeline.completeMultipartUpload(request);
+        } catch (CompletionException e) {
+            throw new S3EncryptionClientException(e.getCause().getMessage(), e.getCause());
+        } catch (Exception e) {
+            throw new S3EncryptionClientException("Unable to delete objects.", e);
+        }
     }
 
     /**

--- a/src/main/java/software/amazon/encryption/s3/S3EncryptionClient.java
+++ b/src/main/java/software/amazon/encryption/s3/S3EncryptionClient.java
@@ -405,7 +405,7 @@ public class S3EncryptionClient extends DelegatingS3Client {
         } catch (CompletionException e) {
             throw new S3EncryptionClientException(e.getCause().getMessage(), e.getCause());
         } catch (Exception e) {
-            throw new S3EncryptionClientException("Unable to delete objects.", e);
+            throw new S3EncryptionClientException("Unable to create Multipart upload.", e);
         }
     }
 
@@ -428,7 +428,7 @@ public class S3EncryptionClient extends DelegatingS3Client {
         } catch (CompletionException e) {
             throw new S3EncryptionClientException(e.getCause().getMessage(), e.getCause());
         } catch (Exception e) {
-            throw new S3EncryptionClientException("Unable to delete objects.", e);
+            throw new S3EncryptionClientException("Unable to upload part.", e);
         }
     }
 
@@ -445,7 +445,7 @@ public class S3EncryptionClient extends DelegatingS3Client {
         } catch (CompletionException e) {
             throw new S3EncryptionClientException(e.getCause().getMessage(), e.getCause());
         } catch (Exception e) {
-            throw new S3EncryptionClientException("Unable to delete objects.", e);
+            throw new S3EncryptionClientException("Unable to complete Multipart upload.", e);
         }
     }
 

--- a/src/test/java/software/amazon/encryption/s3/S3EncryptionClientTest.java
+++ b/src/test/java/software/amazon/encryption/s3/S3EncryptionClientTest.java
@@ -46,6 +46,7 @@ import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -262,7 +263,9 @@ public class S3EncryptionClientTest {
                     .key(objectKey)
                     .build());
         } catch (S3EncryptionClientException expected) {
-            assertTrue(expected.getCause() instanceof NoSuchKeyException);
+            if (!(expected.getCause() instanceof NoSuchKeyException)) {
+                fail("Expected NoSuchKeyException, but was: ", expected.getCause());
+            }
         }
 
         // Cleanup

--- a/src/test/java/software/amazon/encryption/s3/S3EncryptionClientTest.java
+++ b/src/test/java/software/amazon/encryption/s3/S3EncryptionClientTest.java
@@ -262,10 +262,11 @@ public class S3EncryptionClientTest {
                     .bucket(BUCKET)
                     .key(objectKey)
                     .build());
-        } catch (S3EncryptionClientException expected) {
-            if (!(expected.getCause() instanceof NoSuchKeyException)) {
-                fail("Expected NoSuchKeyException, but was: ", expected.getCause());
-            }
+        } catch (S3EncryptionClientException exception) {
+            // Depending on the permissions of the calling principal,
+            // this could be NoSuchKeyException
+            // or S3Exception (access denied)
+            assertTrue(exception.getCause() instanceof S3Exception);
         }
 
         // Cleanup


### PR DESCRIPTION
…ptionClientException

*Issue #, if available:* https://github.com/aws/amazon-s3-encryption-client-java/issues/160

*Description of changes:* The "default" (non-async) S3 Encryption Client implementation is to block on the async API. In all of the operations (except `getObject`), the client does not unwrap the `CompletionException` which the async API wraps any failure with. The default API is expected to not be async, so it should not throw `CompletionException`. Furthermore, S3EC v3 moves to wrapping exceptions in `S3EncryptionClientException` (and its subclasses) so the correct behavior is to unwrap `CompletionException` and rethrow the actual exception wrapped in `S3EncryptionClientException`. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

# Check any applicable:
- [ ] Were any files moved? Moving files changes their URL, which breaks all hyperlinks to the files.
