### PR TITLE
Create default wrapped clients only if necessary.

### DIFF
--- a/src/main/java/software/amazon/encryption/s3/S3EncryptionClient.java
+++ b/src/main/java/software/amazon/encryption/s3/S3EncryptionClient.java
@@ -473,8 +473,8 @@ public class S3EncryptionClient extends DelegatingS3Client {
     // Make sure to keep both clients in mind when adding new builder options
     public static class Builder {
         // The non-encrypted APIs will use a default client.
-        private S3Client _wrappedClient = S3Client.create();
-        private S3AsyncClient _wrappedAsyncClient = S3AsyncClient.create();
+        private S3Client _wrappedClient;
+        private S3AsyncClient _wrappedAsyncClient;
 
         private MultipartUploadObjectPipeline _multipartPipeline;
         private CryptographicMaterialsManager _cryptoMaterialsManager;
@@ -716,6 +716,14 @@ public class S3EncryptionClient extends DelegatingS3Client {
         public S3EncryptionClient build() {
             if (!onlyOneNonNull(_cryptoMaterialsManager, _keyring, _aesKey, _rsaKeyPair, _kmsKeyId)) {
                 throw new S3EncryptionClientException("Exactly one must be set of: crypto materials manager, keyring, AES key, RSA key pair, KMS key id");
+            }
+
+            if (_wrappedClient == null) {
+                _wrappedClient = S3Client.create();
+            }
+
+            if (_wrappedAsyncClient == null) {
+                _wrappedAsyncClient = S3AsyncClient.create();
             }
 
             if (_keyring == null) {


### PR DESCRIPTION
Create the default wrapped clients only if they have not been specified explicitly.

S3Client.create or S3AsyncClient.create can fail in restrictive environments because they attempt to load profiles and credentials from disk, thus requiring java.io.FilePermission.

This patch moves these calls from the class initializer to the build method, so users can prevent the calls by passing their own wrapped clients.

For context: we want to use S3EncryptionClient in an Elasticsearch plugin. Plugins aren't allowed to access arbitrary files such as $HOME/.aws/credentials by default.