### PR TITLE
chore: allow CI to run in forks

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,7 +19,7 @@ jobs:
 
     steps:
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v2
         with:
           role-to-assume: arn:aws:iam::${{ secrets.CI_AWS_ACCOUNT_ID }}:role/service-role/${{ vars.CI_AWS_ROLE }}
           role-session-name: S3EC-Github-CI-Tests

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,9 +21,9 @@ jobs:
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v1
         with:
-          role-to-assume: arn:aws:iam::${{ secrets.CI_AWS_ACCOUNT_ID }}:role/service-role/{{ env.CI_AWS_ROLE }}
+          role-to-assume: arn:aws:iam::${{ secrets.CI_AWS_ACCOUNT_ID }}:role/service-role/${{ env.CI_AWS_ROLE }}
           role-session-name: S3EC-Github-CI-Tests
-          aws-region: {{ env.CI_AWS_REGION }}
+          aws-region: ${{ env.CI_AWS_REGION }}
 
       - name: Checkout Code
         uses: actions/checkout@v3
@@ -46,10 +46,10 @@ jobs:
 
       - name: Test
         run: |
-          export AWS_S3EC_TEST_BUCKET={{ env.CI_S3_BUCKET }}
-          export AWS_S3EC_TEST_KMS_KEY_ID=arn:aws:kms:{{ env.CI_AWS_REGION }}:${{ secrets.CI_AWS_ACCOUNT_ID }}:key/{{ env.CI_KMS_KEY_ID }}
-          export AWS_S3EC_TEST_KMS_KEY_ALIAS=arn:aws:kms:{{ env.CI_AWS_REGION }}:${{ secrets.CI_AWS_ACCOUNT_ID }}:alias/{{ env.CI_KMS_KEY_ALIAS }}
-          export AWS_REGION={{ env.CI_AWS_REGION }}
+          export AWS_S3EC_TEST_BUCKET=${{ env.CI_S3_BUCKET }}
+          export AWS_S3EC_TEST_KMS_KEY_ID=arn:aws:kms:${{ env.CI_AWS_REGION }}:${{ secrets.CI_AWS_ACCOUNT_ID }}:key/${{ env.CI_KMS_KEY_ID }}
+          export AWS_S3EC_TEST_KMS_KEY_ALIAS=arn:aws:kms:${{ env.CI_AWS_REGION }}:${{ secrets.CI_AWS_ACCOUNT_ID }}:alias/${{ env.CI_KMS_KEY_ALIAS }}
+          export AWS_REGION=${{ env.CI_AWS_REGION }}
           mvn -B -ntp test -DskipCompile
         shell: bash
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,9 +21,9 @@ jobs:
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v1
         with:
-          role-to-assume: arn:aws:iam::${{ secrets.CI_AWS_ACCOUNT_ID }}:role/service-role/S3EC-GitHub-test-role
+          role-to-assume: arn:aws:iam::${{ secrets.CI_AWS_ACCOUNT_ID }}:role/service-role/{{ env.CI_AWS_ROLE }}
           role-session-name: S3EC-Github-CI-Tests
-          aws-region: us-west-2
+          aws-region: {{ env.CI_AWS_REGION }}
 
       - name: Checkout Code
         uses: actions/checkout@v3
@@ -46,10 +46,10 @@ jobs:
 
       - name: Test
         run: |
-          export AWS_S3EC_TEST_BUCKET=s3ec-github-test-bucket
-          export AWS_S3EC_TEST_KMS_KEY_ID=arn:aws:kms:us-west-2:${{ secrets.CI_AWS_ACCOUNT_ID }}:key/c3eafb5f-e87d-4584-9400-cf419ce5d782
-          export AWS_S3EC_TEST_KMS_KEY_ALIAS=arn:aws:kms:us-west-2:${{ secrets.CI_AWS_ACCOUNT_ID }}:alias/S3EC-Github-KMS-Key
-          export AWS_REGION=us-west-2
+          export AWS_S3EC_TEST_BUCKET={{ env.CI_S3_BUCKET }}
+          export AWS_S3EC_TEST_KMS_KEY_ID=arn:aws:kms:{{ env.CI_AWS_REGION }}:${{ secrets.CI_AWS_ACCOUNT_ID }}:key/{{ env.CI_KMS_KEY_ID }}
+          export AWS_S3EC_TEST_KMS_KEY_ALIAS=arn:aws:kms:{{ env.CI_AWS_REGION }}:${{ secrets.CI_AWS_ACCOUNT_ID }}:alias/{{ env.CI_KMS_KEY_ALIAS }}
+          export AWS_REGION={{ env.CI_AWS_REGION }}
           mvn -B -ntp test -DskipCompile
         shell: bash
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,9 +21,9 @@ jobs:
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v1
         with:
-          role-to-assume: arn:aws:iam::${{ secrets.CI_AWS_ACCOUNT_ID }}:role/service-role/${{ env.CI_AWS_ROLE }}
+          role-to-assume: arn:aws:iam::${{ secrets.CI_AWS_ACCOUNT_ID }}:role/service-role/${{ vars.CI_AWS_ROLE }}
           role-session-name: S3EC-Github-CI-Tests
-          aws-region: ${{ env.CI_AWS_REGION }}
+          aws-region: ${{ vars.CI_AWS_REGION }}
 
       - name: Checkout Code
         uses: actions/checkout@v3
@@ -46,10 +46,10 @@ jobs:
 
       - name: Test
         run: |
-          export AWS_S3EC_TEST_BUCKET=${{ env.CI_S3_BUCKET }}
-          export AWS_S3EC_TEST_KMS_KEY_ID=arn:aws:kms:${{ env.CI_AWS_REGION }}:${{ secrets.CI_AWS_ACCOUNT_ID }}:key/${{ env.CI_KMS_KEY_ID }}
-          export AWS_S3EC_TEST_KMS_KEY_ALIAS=arn:aws:kms:${{ env.CI_AWS_REGION }}:${{ secrets.CI_AWS_ACCOUNT_ID }}:alias/${{ env.CI_KMS_KEY_ALIAS }}
-          export AWS_REGION=${{ env.CI_AWS_REGION }}
+          export AWS_S3EC_TEST_BUCKET=${{ vars.CI_S3_BUCKET }}
+          export AWS_S3EC_TEST_KMS_KEY_ID=arn:aws:kms:${{ vars.CI_AWS_REGION }}:${{ secrets.CI_AWS_ACCOUNT_ID }}:key/${{ vars.CI_KMS_KEY_ID }}
+          export AWS_S3EC_TEST_KMS_KEY_ALIAS=arn:aws:kms:${{ vars.CI_AWS_REGION }}:${{ secrets.CI_AWS_ACCOUNT_ID }}:alias/${{ vars.CI_KMS_KEY_ALIAS }}
+          export AWS_REGION=${{ vars.CI_AWS_REGION }}
           mvn -B -ntp test -DskipCompile
         shell: bash
 

--- a/README.md
+++ b/README.md
@@ -9,14 +9,14 @@ Integration tests are included. To test them, certain environment variables need
 
 * `AWS_S3EC_TEST_BUCKET` - The bucket to write test values to
 * `AWS_S3EC_TEST_KMS_KEY_ID` - The key ID for the KMS key used for KMS tests
-* `AWS_S3EC_TEST_KMS_KEY_ALIAS` - An alias for the KMS key used for KMS tests. The alias must reference the key ID above. 
+* `AWS_S3EC_TEST_KMS_KEY_ALIAS` - An alias for the KMS key used for KMS tests. The alias must reference the key ID above.
 * `AWS_REGION` - The region the AWS resources (KMS key, S3 bucket) resides e.g. "us-east-1"
 
 To create these resources, refer to the included CloudFormation template (cfn/S3EC-GitHub-CF-Template).
 Make sure that the repo in the trust policy of the IAM role refers to your fork instead of the `aws` organization.
-Note that your account may incur charges based on the usage of any resources beyond the AWS Free Tier. 
+Note that your account may incur charges based on the usage of any resources beyond the AWS Free Tier.
 
-If you have forked this repo, there are additional steps required. 
+If you have forked this repo, there are additional steps required.
 You will need to configure your fork's Github Actions settings to be able to run CI:
 
 Under Settings -> Actions -> General -> Workflow permissions, ensure Read and write permissions is selected.
@@ -24,7 +24,7 @@ Under Settings -> Security -> Secrets and variables -> Actions -> Repository sec
 
 * `CI_AWS_ACCOUNT_ID` - the AWS account ID which contains the required resources, e.g. 111122223333.
 
-The other values are added as variables (by clicking the "New repository variable" button) 
+The other values are added as variables (by clicking the "New repository variable" button):
 
 * `CI_AWS_ROLE` - the IAM role to assume during CI, e.g. S3EC-GitHub-test-role. It must exist in the above account and have permission to call S3 and KMS.
 * `CI_AWS_REGION` - the AWS region which contains the required resources, e.g. us-west-2.

--- a/README.md
+++ b/README.md
@@ -14,12 +14,12 @@ Integration tests are included. To test them, certain environment variables need
 
 To create these resources, refer to the included CloudFormation template (cfn/S3EC-GitHub-CF-Template).
 Make sure that the repo in the trust policy of the IAM role refers to your fork instead of the `aws` organization.
-Note that your account may incur charges based on the usage of any resources beyond the AWS Free Tier.
+**NOTE**: Your account may incur charges based on the usage of any resources beyond the AWS Free Tier.
 
 If you have forked this repo, there are additional steps required.
 You will need to configure your fork's Github Actions settings to be able to run CI:
 
-Under Settings -> Actions -> General -> Workflow permissions, ensure Read and write permissions is selected.
+Under Settings -> Actions -> General -> Workflow permissions, ensure "Read and write permissions" is selected.
 Under Settings -> Security -> Secrets and variables -> Actions -> Repository secrets, add new secret:
 
 * `CI_AWS_ACCOUNT_ID` - the AWS account ID which contains the required resources, e.g. 111122223333.

--- a/README.md
+++ b/README.md
@@ -12,7 +12,13 @@ Integration tests are included. To test them, certain environment variables need
 * `AWS_S3EC_TEST_KMS_KEY_ALIAS` - An alias for the KMS key used for KMS tests. The alias must reference the key ID above. 
 * `AWS_REGION` - The region the AWS resources (KMS key, S3 bucket) resides e.g. "us-east-1"
 
-If you have forked this repo, you need to configure Github Actions with valid AWS resources to be able to run CI. 
+To create these resources, refer to the included CloudFormation template (cfn/S3EC-GitHub-CF-Template).
+Make sure that the repo in the trust policy of the IAM role refers to your fork instead of the `aws` organization.
+Note that your account may incur charges based on the usage of any resources beyond the AWS Free Tier. 
+
+If you have forked this repo, there are additional steps required. 
+You will need to configure your fork's Github Actions settings to be able to run CI:
+
 Under Settings -> Actions -> General -> Workflow permissions, ensure Read and write permissions is selected.
 Under Settings -> Security -> Secrets and variables -> Actions -> Repository secrets, add new secret:
 

--- a/README.md
+++ b/README.md
@@ -8,9 +8,23 @@ for how to use this library, refer to the
 Integration tests are included. To test them, certain environment variables need to be set:
 
 * `AWS_S3EC_TEST_BUCKET` - The bucket to write test values to
-* `AWS_S3EC_TEST_KMS_KEY_ID` - The key id for the KMS key used for KMS tests
+* `AWS_S3EC_TEST_KMS_KEY_ID` - The key ID for the KMS key used for KMS tests
 * `AWS_S3EC_TEST_KMS_KEY_ALIAS` - An alias for the KMS key used for KMS tests. The alias must reference the key ID above. 
 * `AWS_REGION` - The region the AWS resources (KMS key, S3 bucket) resides e.g. "us-east-1"
+
+If you have forked this repo, you need to configure Github Actions with valid AWS resources to be able to run CI. 
+Under Settings -> Actions -> General -> Workflow permissions, ensure Read and write permissions is selected.
+Under Settings -> Security -> Secrets and variables -> Actions -> Repository secrets, add new secret:
+
+* `CI_AWS_ACCOUNT_ID` - the AWS account ID which contains the required resources, e.g. 111122223333.
+
+The other values are added as variables (by clicking the "New repository variable" button) 
+
+* `CI_AWS_ROLE` - the IAM role to assume during CI, e.g. S3EC-GitHub-test-role. It must exist in the above account and have permission to call S3 and KMS.
+* `CI_AWS_REGION` - the AWS region which contains the required resources, e.g. us-west-2.
+* `CI_S3_BUCKET` - the S3 bucket to use, e.g. s3ec-github-test-bucket.
+* `CI_KMS_KEY_ID` - the short KMS key ID to use, e.g. c3eafb5f-e87d-4584-9400-cf419ce5d782.
+* `CI_KMS_KEY_ALIAS` - the KMS key alias to use, e.g. S3EC-Github-KMS-Key. Note that the alias must reference the key ID above.
 
 ## Migration
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Previously, the CI used hard-coded AWS resource identifiers to run against, which makes running CI in a fork of the repo functionally impossible. 
This change moves the CI to use the repository's Action variables to specify the resources, so that forks can configure their own AWS resources. 
This _does not_ allow execution of 3p PRs against the upstream repo when the submitting fork has not gone through the setup process. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

# Check any applicable:
- [ ] Were any files moved? Moving files changes their URL, which breaks all hyperlinks to the files.
