### PR TITLE
feat: Refactor `KmsKeyring` to use `GenerateDataKey` instead of `Encrypt`

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -47,8 +47,8 @@ jobs:
       - name: Test
         run: |
           export AWS_S3EC_TEST_BUCKET=${{ vars.CI_S3_BUCKET }}
-          export AWS_S3EC_TEST_KMS_KEY_ID=arn:aws:kms:${{ vars.CI_AWS_REGION }}:${{ secrets.CI_AWS_ACCOUNT_ID }}:key/${{ vars.CI_KMS_KEY_ID }}
-          export AWS_S3EC_TEST_KMS_KEY_ALIAS=arn:aws:kms:${{ vars.CI_AWS_REGION }}:${{ secrets.CI_AWS_ACCOUNT_ID }}:alias/${{ vars.CI_KMS_KEY_ALIAS }}
+          export AWS_S3EC_TEST_KMS_KEY_ID=arn:aws:kms:us-west-2:452750982249:key/086db65a-4b1d-4801-8c7b-f2fda0c33309
+          export AWS_S3EC_TEST_KMS_KEY_ALIAS=arn:aws:kms:us-west-2:452750982249:alias/S3EC-Github-KMS-Key
           export AWS_REGION=${{ vars.CI_AWS_REGION }}
           mvn -B -ntp test -DskipCompile
         shell: bash

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,7 +19,7 @@ jobs:
 
     steps:
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v3
+        uses: aws-actions/configure-aws-credentials@v2
         with:
           role-to-assume: arn:aws:iam::${{ secrets.CI_AWS_ACCOUNT_ID }}:role/service-role/${{ vars.CI_AWS_ROLE }}
           role-session-name: S3EC-Github-CI-Tests

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -46,10 +46,10 @@ jobs:
 
       - name: Test
         run: |
-          export AWS_S3EC_TEST_BUCKET=s3ec-github-test-bucket-generate
-          export AWS_S3EC_TEST_KMS_KEY_ID=arn:aws:kms:us-west-2:452750982249:key/086db65a-4b1d-4801-8c7b-f2fda0c33309
-          export AWS_S3EC_TEST_KMS_KEY_ALIAS=arn:aws:kms:us-west-2:452750982249:alias/S3EC-Github-KMS-Key
-          export AWS_REGION=us-west-2
+          export AWS_S3EC_TEST_BUCKET=${{ vars.CI_S3_BUCKET }}
+          export AWS_S3EC_TEST_KMS_KEY_ID=arn:aws:kms:${{ vars.CI_AWS_REGION }}:${{ secrets.CI_AWS_ACCOUNT_ID }}:key/${{ vars.CI_KMS_KEY_ID }}
+          export AWS_S3EC_TEST_KMS_KEY_ALIAS=arn:aws:kms:${{ vars.CI_AWS_REGION }}:${{ secrets.CI_AWS_ACCOUNT_ID }}:alias/${{ vars.CI_KMS_KEY_ALIAS }}
+          export AWS_REGION=${{ vars.CI_AWS_REGION }}
           mvn -B -ntp test -DskipCompile
         shell: bash
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -46,10 +46,10 @@ jobs:
 
       - name: Test
         run: |
-          export AWS_S3EC_TEST_BUCKET=${{ vars.CI_S3_BUCKET }}
+          export AWS_S3EC_TEST_BUCKET=s3ec-github-test-bucket-generate
           export AWS_S3EC_TEST_KMS_KEY_ID=arn:aws:kms:us-west-2:452750982249:key/086db65a-4b1d-4801-8c7b-f2fda0c33309
           export AWS_S3EC_TEST_KMS_KEY_ALIAS=arn:aws:kms:us-west-2:452750982249:alias/S3EC-Github-KMS-Key
-          export AWS_REGION=${{ vars.CI_AWS_REGION }}
+          export AWS_REGION=us-west-2
           mvn -B -ntp test -DskipCompile
         shell: bash
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,7 +19,7 @@ jobs:
 
     steps:
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v2
+        uses: aws-actions/configure-aws-credentials@v3
         with:
           role-to-assume: arn:aws:iam::${{ secrets.CI_AWS_ACCOUNT_ID }}:role/service-role/${{ vars.CI_AWS_ROLE }}
           role-session-name: S3EC-Github-CI-Tests

--- a/cfn/release.yml
+++ b/cfn/release.yml
@@ -214,7 +214,6 @@ Resources:
                 "arn:aws:kms:*:658956600833:alias/*"
               ],
               "Action": [
-                "kms:Encrypt",
                 "kms:Decrypt",
                 "kms:GenerateDataKey"
               ]

--- a/src/main/java/software/amazon/encryption/s3/materials/EncryptDataKeyStrategy.java
+++ b/src/main/java/software/amazon/encryption/s3/materials/EncryptDataKeyStrategy.java
@@ -8,6 +8,10 @@ import java.security.SecureRandom;
 public interface EncryptDataKeyStrategy {
     String keyProviderInfo();
 
+    default boolean isKms(){
+        return false;
+    }
+
     default EncryptionMaterials modifyMaterials(EncryptionMaterials materials) {
         return materials;
     }

--- a/src/main/java/software/amazon/encryption/s3/materials/EncryptDataKeyStrategy.java
+++ b/src/main/java/software/amazon/encryption/s3/materials/EncryptDataKeyStrategy.java
@@ -2,6 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 package software.amazon.encryption.s3.materials;
 
+import software.amazon.awssdk.services.kms.model.GenerateDataKeyResponse;
+
 import java.security.GeneralSecurityException;
 import java.security.SecureRandom;
 
@@ -14,6 +16,10 @@ public interface EncryptDataKeyStrategy {
 
     default EncryptionMaterials modifyMaterials(EncryptionMaterials materials) {
         return materials;
+    }
+
+    default GenerateDataKeyResponse generateDataKey(EncryptionMaterials materials) {
+        return null;
     }
 
     byte[] encryptDataKey(


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

- Refactor `KmsKeyring` to use `GenerateDataKey` instead of `Encrypt`
- Update CloudFormation template, to allow IAM Role to remove `Encrypt` and only perform `GenerateDataKey` operation.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

# Check any applicable:
- [ ] Were any files moved? Moving files changes their URL, which breaks all hyperlinks to the files.
