### PR TITLE
feat: Refactor `KmsKeyring` to use `GenerateDataKey` instead of `Encrypt`

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,8 +40,8 @@ jobs:
 
       - name: Compile
         run: |
-          mvn -B -ntp clean compile
-          mvn -B -ntp test-compile
+          mvn --batch-mode -no-transfer-progress clean compile
+          mvn --batch-mode -no-transfer-progress test-compile
         shell: bash
 
       - name: Test

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,8 +40,8 @@ jobs:
 
       - name: Compile
         run: |
-          mvn clean compile
-          mvn test-compile
+          mvn -B -ntp clean compile
+          mvn -B -ntp test-compile
         shell: bash
 
       - name: Test
@@ -55,5 +55,5 @@ jobs:
 
       - name: Package JAR
         run: |
-          mvn install -DskipTests
+          mvn -B -ntp install -DskipTests
         shell: bash

--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -3,6 +3,9 @@ name: Continuous Integration Workflow
 on:
   pull_request:
   push:
+  # Run once a day
+  schedule:
+    - cron: '0 0 * * *'
 
 jobs:
   Static_Analysis:
@@ -10,7 +13,7 @@ jobs:
 
   Build:
     strategy:
-      max-parallel: 1 # TODO: Fix jobs failing when running in parallel
+      fail-fast: true
       matrix:
         version: [ 8, 11, 17 ]
         distribution: [ corretto, temurin ] # TODO: Add OpenJDK

--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -3,9 +3,9 @@ name: Continuous Integration Workflow
 on:
   pull_request:
   push:
-  # Run once a day
+  # This workflow runs every weekday at 15:00 UTC (8AM PDT)
   schedule:
-    - cron: '0 0 * * *'
+    - cron: '00 15 * * 1-5'
 
 jobs:
   Static_Analysis:

--- a/cfn/release.yml
+++ b/cfn/release.yml
@@ -214,7 +214,6 @@ Resources:
                 "arn:aws:kms:*:658956600833:alias/*"
               ],
               "Action": [
-                "kms:Encrypt",
                 "kms:Decrypt",
                 "kms:GenerateDataKey"
               ]

--- a/src/main/java/software/amazon/encryption/s3/materials/AesKeyring.java
+++ b/src/main/java/software/amazon/encryption/s3/materials/AesKeyring.java
@@ -139,16 +139,16 @@ public class AesKeyring extends S3Keyring {
         }
     };
 
-    private final Map<String, DecryptDataKeyStrategy> decryptStrategies = new HashMap<>();
+    private final Map<String, DecryptDataKeyStrategy> decryptDataKeyStrategies = new HashMap<>();
 
     private AesKeyring(Builder builder) {
         super(builder);
 
         _wrappingKey = builder._wrappingKey;
 
-        decryptStrategies.put(_aesStrategy.keyProviderInfo(), _aesStrategy);
-        decryptStrategies.put(_aesWrapStrategy.keyProviderInfo(), _aesWrapStrategy);
-        decryptStrategies.put(_aesGcmStrategy.keyProviderInfo(), _aesGcmStrategy);
+        decryptDataKeyStrategies.put(_aesStrategy.keyProviderInfo(), _aesStrategy);
+        decryptDataKeyStrategies.put(_aesWrapStrategy.keyProviderInfo(), _aesWrapStrategy);
+        decryptDataKeyStrategies.put(_aesGcmStrategy.keyProviderInfo(), _aesGcmStrategy);
     }
 
     public static Builder builder() {
@@ -156,18 +156,18 @@ public class AesKeyring extends S3Keyring {
     }
 
     @Override
-    protected GenerateDataKeyStrategy generateStrategy() {
+    protected GenerateDataKeyStrategy generateDataKeyStrategy() {
         return _aesGcmStrategy;
     }
 
     @Override
-    protected EncryptDataKeyStrategy encryptStrategy() {
+    protected EncryptDataKeyStrategy encryptDataKeyStrategy() {
         return _aesGcmStrategy;
     }
 
     @Override
-    protected Map<String, DecryptDataKeyStrategy> decryptStrategies() {
-        return decryptStrategies;
+    protected Map<String, DecryptDataKeyStrategy> decryptDataKeyStrategies() {
+        return decryptDataKeyStrategies;
     }
 
     public static class Builder extends S3Keyring.Builder<AesKeyring, Builder> {

--- a/src/main/java/software/amazon/encryption/s3/materials/DataKeyStrategy.java
+++ b/src/main/java/software/amazon/encryption/s3/materials/DataKeyStrategy.java
@@ -2,6 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 package software.amazon.encryption.s3.materials;
 
-public abstract class DataKeyStrategy implements EncryptDataKeyStrategy, DecryptDataKeyStrategy {
+public abstract class DataKeyStrategy implements GenerateDataKeyStrategy, EncryptDataKeyStrategy, DecryptDataKeyStrategy {
 
 }

--- a/src/main/java/software/amazon/encryption/s3/materials/EncryptDataKeyStrategy.java
+++ b/src/main/java/software/amazon/encryption/s3/materials/EncryptDataKeyStrategy.java
@@ -2,24 +2,14 @@
 // SPDX-License-Identifier: Apache-2.0
 package software.amazon.encryption.s3.materials;
 
-import software.amazon.awssdk.services.kms.model.GenerateDataKeyResponse;
-
 import java.security.GeneralSecurityException;
 import java.security.SecureRandom;
 
 public interface EncryptDataKeyStrategy {
     String keyProviderInfo();
 
-    default boolean isKms(){
-        return false;
-    }
-
     default EncryptionMaterials modifyMaterials(EncryptionMaterials materials) {
         return materials;
-    }
-
-    default GenerateDataKeyResponse generateDataKey(EncryptionMaterials materials) {
-        return null;
     }
 
     byte[] encryptDataKey(

--- a/src/main/java/software/amazon/encryption/s3/materials/EncryptDataKeyStrategy.java
+++ b/src/main/java/software/amazon/encryption/s3/materials/EncryptDataKeyStrategy.java
@@ -2,14 +2,24 @@
 // SPDX-License-Identifier: Apache-2.0
 package software.amazon.encryption.s3.materials;
 
+import software.amazon.awssdk.services.kms.model.GenerateDataKeyResponse;
+
 import java.security.GeneralSecurityException;
 import java.security.SecureRandom;
 
 public interface EncryptDataKeyStrategy {
     String keyProviderInfo();
 
+    default boolean isKms(){
+        return false;
+    }
+
     default EncryptionMaterials modifyMaterials(EncryptionMaterials materials) {
         return materials;
+    }
+
+    default GenerateDataKeyResponse generateDataKey(EncryptionMaterials materials) {
+        return null;
     }
 
     byte[] encryptDataKey(

--- a/src/main/java/software/amazon/encryption/s3/materials/GenerateDataKeyStrategy.java
+++ b/src/main/java/software/amazon/encryption/s3/materials/GenerateDataKeyStrategy.java
@@ -1,8 +1,5 @@
 package software.amazon.encryption.s3.materials;
 
-import java.security.GeneralSecurityException;
-import java.security.SecureRandom;
-
 public interface GenerateDataKeyStrategy {
     String keyProviderInfo();
 

--- a/src/main/java/software/amazon/encryption/s3/materials/GenerateDataKeyStrategy.java
+++ b/src/main/java/software/amazon/encryption/s3/materials/GenerateDataKeyStrategy.java
@@ -1,0 +1,10 @@
+package software.amazon.encryption.s3.materials;
+
+import java.security.GeneralSecurityException;
+import java.security.SecureRandom;
+
+public interface GenerateDataKeyStrategy {
+    String keyProviderInfo();
+
+    EncryptionMaterials generateDataKey(EncryptionMaterials materials);
+}

--- a/src/main/java/software/amazon/encryption/s3/materials/KmsKeyring.java
+++ b/src/main/java/software/amazon/encryption/s3/materials/KmsKeyring.java
@@ -127,7 +127,7 @@ public class KmsKeyring extends S3Keyring {
 
             GenerateDataKeyRequest request = GenerateDataKeyRequest.builder()
                     .keyId(_wrappingKeyId)
-                    .keySpec(dataKeySpec.toString())
+                    .keySpec(dataKeySpec)
                     .encryptionContext(materials.encryptionContext())
                     .overrideConfiguration(builder -> builder.addApiName(API_NAME))
                     .build();

--- a/src/main/java/software/amazon/encryption/s3/materials/RsaKeyring.java
+++ b/src/main/java/software/amazon/encryption/s3/materials/RsaKeyring.java
@@ -158,16 +158,16 @@ public class RsaKeyring extends S3Keyring {
         }
     };
 
-    private final Map<String, DecryptDataKeyStrategy> decryptStrategies = new HashMap<>();
+    private final Map<String, DecryptDataKeyStrategy> decryptDataKeyStrategies = new HashMap<>();
 
     private RsaKeyring(Builder builder) {
         super(builder);
 
         _partialRsaKeyPair = builder._partialRsaKeyPair;
 
-        decryptStrategies.put(_rsaStrategy.keyProviderInfo(), _rsaStrategy);
-        decryptStrategies.put(_rsaEcbStrategy.keyProviderInfo(), _rsaEcbStrategy);
-        decryptStrategies.put(_rsaOaepStrategy.keyProviderInfo(), _rsaOaepStrategy);
+        decryptDataKeyStrategies.put(_rsaStrategy.keyProviderInfo(), _rsaStrategy);
+        decryptDataKeyStrategies.put(_rsaEcbStrategy.keyProviderInfo(), _rsaEcbStrategy);
+        decryptDataKeyStrategies.put(_rsaOaepStrategy.keyProviderInfo(), _rsaOaepStrategy);
     }
 
     public static Builder builder() {
@@ -175,18 +175,18 @@ public class RsaKeyring extends S3Keyring {
     }
 
     @Override
-    protected GenerateDataKeyStrategy generateStrategy() {
+    protected GenerateDataKeyStrategy generateDataKeyStrategy() {
         return _rsaOaepStrategy;
     }
 
     @Override
-    protected EncryptDataKeyStrategy encryptStrategy() {
+    protected EncryptDataKeyStrategy encryptDataKeyStrategy() {
         return _rsaOaepStrategy;
     }
 
     @Override
-    protected Map<String, DecryptDataKeyStrategy> decryptStrategies() {
-        return decryptStrategies;
+    protected Map<String, DecryptDataKeyStrategy> decryptDataKeyStrategies() {
+        return decryptDataKeyStrategies;
     }
 
     public static class Builder extends S3Keyring.Builder<S3Keyring, Builder> {

--- a/src/main/java/software/amazon/encryption/s3/materials/RsaKeyring.java
+++ b/src/main/java/software/amazon/encryption/s3/materials/RsaKeyring.java
@@ -98,6 +98,11 @@ public class RsaKeyring extends S3Keyring {
         }
 
         @Override
+        public EncryptionMaterials generateDataKey(EncryptionMaterials materials) {
+            return defaultGenerateDataKey(materials);
+        }
+
+        @Override
         public byte[] encryptDataKey(SecureRandom secureRandom,
                                      EncryptionMaterials materials) throws GeneralSecurityException {
             final Cipher cipher = CryptoFactory.createCipher(CIPHER_ALGORITHM, materials.cryptoProvider());
@@ -167,6 +172,11 @@ public class RsaKeyring extends S3Keyring {
 
     public static Builder builder() {
         return new Builder();
+    }
+
+    @Override
+    protected GenerateDataKeyStrategy generateStrategy() {
+        return _rsaOaepStrategy;
     }
 
     @Override

--- a/src/main/java/software/amazon/encryption/s3/materials/S3Keyring.java
+++ b/src/main/java/software/amazon/encryption/s3/materials/S3Keyring.java
@@ -30,13 +30,23 @@ abstract public class S3Keyring implements Keyring {
         _dataKeyGenerator = builder._dataKeyGenerator;
     }
 
+    /**
+     * Generates a data key using the provided EncryptionMaterials and the configured DataKeyGenerator.
+     * <p>
+     * This method is intended for extension by customers who need to customize key generation within their Keyring
+     * implementation. It generates a data key for encryption using the algorithm suite and cryptographic provider
+     * configured in the provided EncryptionMaterials object.
+     *
+     * @param materials The EncryptionMaterials containing information about the algorithm suite and cryptographic
+     *                  provider to be used for data key generation.
+     * @return An updated EncryptionMaterials object with the generated plaintext data key.
+     */
     public EncryptionMaterials defaultGenerateDataKey(EncryptionMaterials materials) {
         SecretKey dataKey = _dataKeyGenerator.generateDataKey(materials.algorithmSuite(), materials.cryptoProvider());
         return materials.toBuilder()
                 .plaintextDataKey(dataKey.getEncoded())
                 .build();
     }
-
 
     @Override
     public EncryptionMaterials onEncrypt(EncryptionMaterials materials) {

--- a/src/main/java/software/amazon/encryption/s3/materials/S3Keyring.java
+++ b/src/main/java/software/amazon/encryption/s3/materials/S3Keyring.java
@@ -40,13 +40,13 @@ abstract public class S3Keyring implements Keyring {
 
     @Override
     public EncryptionMaterials onEncrypt(EncryptionMaterials materials) {
-        EncryptDataKeyStrategy encryptStrategy = encryptStrategy();
+        EncryptDataKeyStrategy encryptStrategy = encryptDataKeyStrategy();
 
         // Allow encrypt strategy to modify the materials if necessary
         materials = encryptStrategy.modifyMaterials(materials);
 
         if (materials.plaintextDataKey() == null) {
-            materials = generateStrategy().generateDataKey(materials);
+            materials = generateDataKeyStrategy().generateDataKey(materials);
         }
 
         // Return materials if they already have an encrypted data key.
@@ -73,9 +73,9 @@ abstract public class S3Keyring implements Keyring {
         }
     }
 
-    abstract protected GenerateDataKeyStrategy generateStrategy();
+    abstract protected GenerateDataKeyStrategy generateDataKeyStrategy();
 
-    abstract protected EncryptDataKeyStrategy encryptStrategy();
+    abstract protected EncryptDataKeyStrategy encryptDataKeyStrategy();
 
     @Override
     public DecryptionMaterials onDecrypt(final DecryptionMaterials materials, List<EncryptedDataKey> encryptedDataKeys) {
@@ -95,7 +95,7 @@ abstract public class S3Keyring implements Keyring {
 
         String keyProviderInfo = new String(encryptedDataKey.keyProviderInfo(), StandardCharsets.UTF_8);
 
-        DecryptDataKeyStrategy decryptStrategy = decryptStrategies().get(keyProviderInfo);
+        DecryptDataKeyStrategy decryptStrategy = decryptDataKeyStrategies().get(keyProviderInfo);
         if (decryptStrategy == null) {
             throw new S3EncryptionClientException("The keyring does not support the object's key wrapping algorithm: " + keyProviderInfo);
         }
@@ -112,7 +112,7 @@ abstract public class S3Keyring implements Keyring {
         }
     }
 
-    abstract protected Map<String, DecryptDataKeyStrategy> decryptStrategies();
+    abstract protected Map<String, DecryptDataKeyStrategy> decryptDataKeyStrategies();
 
     abstract public static class Builder<KeyringT extends S3Keyring, BuilderT extends Builder<KeyringT, BuilderT>> {
         private boolean _enableLegacyWrappingAlgorithms = false;

--- a/src/main/java/software/amazon/encryption/s3/materials/S3Keyring.java
+++ b/src/main/java/software/amazon/encryption/s3/materials/S3Keyring.java
@@ -3,6 +3,7 @@
 package software.amazon.encryption.s3.materials;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import software.amazon.awssdk.services.kms.model.GenerateDataKeyResponse;
 import software.amazon.encryption.s3.S3EncryptionClientException;
 
 import javax.crypto.SecretKey;
@@ -12,6 +13,7 @@ import java.security.SecureRandom;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
 /**
  * This serves as the base class for all the keyrings in the S3 encryption client.
@@ -33,23 +35,37 @@ abstract public class S3Keyring implements Keyring {
 
     @Override
     public EncryptionMaterials onEncrypt(EncryptionMaterials materials) {
-        if (materials.plaintextDataKey() == null) {
-            SecretKey dataKey = _dataKeyGenerator.generateDataKey(materials.algorithmSuite(), materials.cryptoProvider());
-            materials = materials.toBuilder()
-                    .plaintextDataKey(dataKey.getEncoded())
-                    .build();
-        }
-
         EncryptDataKeyStrategy encryptStrategy = encryptStrategy();
         try {
+            if (materials.plaintextDataKey() == null && !encryptStrategy.isKms()) {
+                SecretKey dataKey = _dataKeyGenerator.generateDataKey(materials.algorithmSuite(), materials.cryptoProvider());
+                materials = materials.toBuilder()
+                        .plaintextDataKey(dataKey.getEncoded())
+                        .build();
+            }
+
             // Allow encrypt strategy to modify the materials if necessary
             materials = encryptStrategy.modifyMaterials(materials);
 
-            byte[] encryptedDataKeyCiphertext = encryptStrategy.encryptDataKey(_secureRandom, materials);
+            byte[] encryptedDataKeyCiphertext;
+
+            if (encryptStrategy.isKms()) {
+                // Since generateDataKey already performs the Encrypt operation and
+                // returns both plaintext and ciphertext data keys,
+                // calling encryptDataKey separately is not required.
+                GenerateDataKeyResponse response = encryptStrategy.generateDataKey(materials);
+                materials = materials.toBuilder()
+                        .plaintextDataKey(response.plaintext().asByteArray())
+                        .build();
+                encryptedDataKeyCiphertext = response.ciphertextBlob().asByteArray();
+            } else {
+                encryptedDataKeyCiphertext = encryptStrategy.encryptDataKey(_secureRandom, materials);
+            }
+
             EncryptedDataKey encryptedDataKey = EncryptedDataKey.builder()
                     .keyProviderId(S3Keyring.KEY_PROVIDER_ID)
                     .keyProviderInfo(encryptStrategy.keyProviderInfo().getBytes(StandardCharsets.UTF_8))
-                    .encryptedDataKey(encryptedDataKeyCiphertext)
+                    .encryptedDataKey(Objects.requireNonNull(encryptedDataKeyCiphertext))
                     .build();
 
             List<EncryptedDataKey> encryptedDataKeys = new ArrayList<>(materials.encryptedDataKeys());

--- a/src/test/java/software/amazon/encryption/s3/ParameterMalleabilityTest.java
+++ b/src/test/java/software/amazon/encryption/s3/ParameterMalleabilityTest.java
@@ -15,6 +15,7 @@ import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static software.amazon.encryption.s3.utils.S3EncryptionClientTestResources.BUCKET;
+import static software.amazon.encryption.s3.utils.S3EncryptionClientTestResources.appendTestSuffix;
 import static software.amazon.encryption.s3.utils.S3EncryptionClientTestResources.deleteObject;
 
 public class ParameterMalleabilityTest {
@@ -30,7 +31,7 @@ public class ParameterMalleabilityTest {
 
     @Test
     public void contentEncryptionDowngradeAttackFails() {
-        final String objectKey = "content-downgrade-attack-fails";
+        final String objectKey = appendTestSuffix("content-downgrade-attack-fails");
         S3Client v3Client = S3EncryptionClient.builder()
                 .aesKey(AES_KEY)
                 .build();
@@ -69,7 +70,7 @@ public class ParameterMalleabilityTest {
 
     @Test
     public void keyWrapRemovalAttackFails() {
-        final String objectKey = "keywrap-removal-attack-fails";
+        final String objectKey = appendTestSuffix("keywrap-removal-attack-fails");
         S3Client v3Client = S3EncryptionClient.builder()
                 .aesKey(AES_KEY)
                 .build();
@@ -107,7 +108,7 @@ public class ParameterMalleabilityTest {
 
     @Test
     public void keyWrapDowngradeAesWrapAttackFails() {
-        final String objectKey = "keywrap-downgrade-aeswrap-attack-fails";
+        final String objectKey = appendTestSuffix("keywrap-downgrade-aeswrap-attack-fails");
         S3Client v3Client = S3EncryptionClient.builder()
                 .aesKey(AES_KEY)
                 .build();
@@ -146,7 +147,7 @@ public class ParameterMalleabilityTest {
 
     @Test
     public void keyWrapDowngradeAesAttackFails() {
-        final String objectKey = "keywrap-downgrade-aes-attack-fails";
+        final String objectKey = appendTestSuffix("keywrap-downgrade-aes-attack-fails");
         S3Client v3Client = S3EncryptionClient.builder()
                 .aesKey(AES_KEY)
                 .build();

--- a/src/test/java/software/amazon/encryption/s3/S3EncryptionClientCompatibilityTest.java
+++ b/src/test/java/software/amazon/encryption/s3/S3EncryptionClientCompatibilityTest.java
@@ -806,7 +806,7 @@ public class S3EncryptionClientCompatibilityTest {
 
     @Test
     public void AesCbcV1toV3FailsWhenUnauthencticateModeDisabled() {
-        final String objectKey = "fails-aes-cbc-v1-to-v3-when-unauthencticate-mode-disabled";
+        final String objectKey = appendTestSuffix("fails-aes-cbc-v1-to-v3-when-unauthencticate-mode-disabled");
 
         // V1 Client
         EncryptionMaterialsProvider materialsProvider =
@@ -840,7 +840,7 @@ public class S3EncryptionClientCompatibilityTest {
 
     @Test
     public void AesCbcV1toV3FailsWhenLegacyKeyringDisabled() {
-        final String objectKey = "fails-aes-cbc-v1-to-v3-when-legacy-keyring-disabled";
+        final String objectKey = appendTestSuffix("fails-aes-cbc-v1-to-v3-when-legacy-keyring-disabled");
 
         // V1 Client
         EncryptionMaterialsProvider materialsProvider =

--- a/src/test/java/software/amazon/encryption/s3/S3EncryptionClientStreamTest.java
+++ b/src/test/java/software/amazon/encryption/s3/S3EncryptionClientStreamTest.java
@@ -275,7 +275,7 @@ public class S3EncryptionClientStreamTest {
 
     @Test
     public void AesGcmV3toV3StreamWithTamperedTag() {
-        final String objectKey = "aes-gcm-v3-to-v3-stream-tamper-tag";
+        final String objectKey = appendTestSuffix("aes-gcm-v3-to-v3-stream-tamper-tag");
 
         // V3 Client
         S3Client v3Client = S3EncryptionClient.builder()

--- a/src/test/java/software/amazon/encryption/s3/S3EncryptionClientTest.java
+++ b/src/test/java/software/amazon/encryption/s3/S3EncryptionClientTest.java
@@ -584,7 +584,7 @@ public class S3EncryptionClientTest {
 
     @Test
     public void attemptToDecryptPlaintext() {
-        final String objectKey = "plaintext-object";
+        final String objectKey = appendTestSuffix("plaintext-object");
 
         final S3Client plaintextS3Client = S3Client.builder().build();
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

- Refactor `KmsKeyring` to use `GenerateDataKey` instead of `Encrypt`
- Update CloudFormation template, to allow IAM Role to remove `Encrypt` and only perform `GenerateDataKey` operation.
- Update CI Workflow to Run CI tests parallel and daily.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

# Check any applicable:
- [ ] Were any files moved? Moving files changes their URL, which breaks all hyperlinks to the files.
