### PR TITLE
chore: warn against use of Encryption Context for non-kms keyrings.

### DIFF
--- a/src/main/java/software/amazon/encryption/s3/materials/AesKeyring.java
+++ b/src/main/java/software/amazon/encryption/s3/materials/AesKeyring.java
@@ -99,6 +99,13 @@ public class AesKeyring extends S3Keyring {
         }
 
         @Override
+        public EncryptionMaterials modifyMaterials(EncryptionMaterials materials) {
+            warnIfEncryptionContextIsPresent(materials);
+
+            return materials;
+        }
+
+        @Override
         public byte[] encryptDataKey(SecureRandom secureRandom,
                 EncryptionMaterials materials)
                 throws GeneralSecurityException {

--- a/src/main/java/software/amazon/encryption/s3/materials/RsaKeyring.java
+++ b/src/main/java/software/amazon/encryption/s3/materials/RsaKeyring.java
@@ -103,6 +103,13 @@ public class RsaKeyring extends S3Keyring {
         }
 
         @Override
+        public EncryptionMaterials modifyMaterials(EncryptionMaterials materials) {
+            warnIfEncryptionContextIsPresent(materials);
+
+            return materials;
+        }
+
+        @Override
         public byte[] encryptDataKey(SecureRandom secureRandom,
                                      EncryptionMaterials materials) throws GeneralSecurityException {
             final Cipher cipher = CryptoFactory.createCipher(CIPHER_ALGORITHM, materials.cryptoProvider());

--- a/src/main/java/software/amazon/encryption/s3/materials/S3Keyring.java
+++ b/src/main/java/software/amazon/encryption/s3/materials/S3Keyring.java
@@ -3,6 +3,7 @@
 package software.amazon.encryption.s3.materials;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import software.amazon.encryption.s3.S3EncryptionClient;
 import software.amazon.encryption.s3.S3EncryptionClientException;
 
 import java.nio.charset.StandardCharsets;
@@ -12,6 +13,8 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import javax.crypto.SecretKey;
+
+import org.apache.commons.logging.LogFactory;
 
 /**
  * This serves as the base class for all the keyrings in the S3 encryption client.
@@ -123,6 +126,15 @@ abstract public class S3Keyring implements Keyring {
     }
 
     abstract protected Map<String, DecryptDataKeyStrategy> decryptDataKeyStrategies();
+
+    public void warnIfEncryptionContextIsPresent(EncryptionMaterials materials) {
+        materials.s3Request().overrideConfiguration()
+                .flatMap(overrideConfiguration ->
+                                 overrideConfiguration.executionAttributes()
+                                         .getOptionalAttribute(S3EncryptionClient.ENCRYPTION_CONTEXT))
+                .ifPresent(ctx -> LogFactory.getLog(getClass()).warn("Usage of Encryption Context provides no security benefit in " + getClass().getSimpleName()));
+
+    }
 
     abstract public static class Builder<KeyringT extends S3Keyring, BuilderT extends Builder<KeyringT, BuilderT>> {
         private boolean _enableLegacyWrappingAlgorithms = false;

--- a/src/main/java/software/amazon/encryption/s3/materials/S3Keyring.java
+++ b/src/main/java/software/amazon/encryption/s3/materials/S3Keyring.java
@@ -127,6 +127,15 @@ abstract public class S3Keyring implements Keyring {
 
     abstract protected Map<String, DecryptDataKeyStrategy> decryptDataKeyStrategies();
 
+    /**
+     * Checks if an encryption context is present in the EncryptionMaterials and issues a warning
+     * if an encryption context is found.
+     * <p>
+     * Encryption context is not recommended for use with
+     * non-KMS keyrings as it may not provide additional security benefits.
+     *
+     * @param materials EncryptionMaterials
+     */
     public void warnIfEncryptionContextIsPresent(EncryptionMaterials materials) {
         materials.s3Request().overrideConfiguration()
                 .flatMap(overrideConfiguration ->


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

- Throw a warn against use of Encryption Context for non-KmsKeyring's (i.e AesKeyring or RsaKering).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

# Check any applicable:
- [ ] Were any files moved? Moving files changes their URL, which breaks all hyperlinks to the files.
