### PR TITLE
chore: update node version in version step

### DIFF
--- a/codebuild/release/version.yml
+++ b/codebuild/release/version.yml
@@ -14,7 +14,7 @@ env:
 phases:
   install:
     commands:
-      - n 18 # semantic-release wants 18, the image only goes up to 16
+      - n 20 # semantic-release wants 20, the image only goes up to 16
       - npm install --save-dev semantic-release
       - npm install @semantic-release/changelog -d
       - npm install @semantic-release/exec -d


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Release failed:

```
node version >=20.8.1 is required. Found v18.19.0.
```

This updates the node version we install during the `version` step. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

# Check any applicable:
- [ ] Were any files moved? Moving files changes their URL, which breaks all hyperlinks to the files.
