### PR TITLE
fix: create clients only if necessary

### DIFF
--- a/src/main/java/software/amazon/encryption/s3/S3AsyncEncryptionClient.java
+++ b/src/main/java/software/amazon/encryption/s3/S3AsyncEncryptionClient.java
@@ -251,7 +251,7 @@ public class S3AsyncEncryptionClient extends DelegatingS3AsyncClient {
     // This is very similar to the S3EncryptionClient builder
     // Make sure to keep both clients in mind when adding new builder options
     public static class Builder {
-        private S3AsyncClient _wrappedClient = S3AsyncClient.builder().build();
+        private S3AsyncClient _wrappedClient;
         private CryptographicMaterialsManager _cryptoMaterialsManager;
         private Keyring _keyring;
         private SecretKey _aesKey;
@@ -505,6 +505,10 @@ public class S3AsyncEncryptionClient extends DelegatingS3AsyncClient {
                 }
             } else {
                 _bufferSize = DEFAULT_BUFFER_SIZE_BYTES;
+            }
+
+            if (_wrappedClient == null) {
+                _wrappedClient = S3AsyncClient.create();
             }
 
             if (_keyring == null) {

--- a/src/main/java/software/amazon/encryption/s3/materials/KmsKeyring.java
+++ b/src/main/java/software/amazon/encryption/s3/materials/KmsKeyring.java
@@ -14,6 +14,7 @@ import software.amazon.awssdk.services.kms.model.EncryptRequest;
 import software.amazon.awssdk.services.kms.model.EncryptResponse;
 import software.amazon.awssdk.services.kms.model.GenerateDataKeyRequest;
 import software.amazon.awssdk.services.kms.model.GenerateDataKeyResponse;
+import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.model.GetObjectRequest;
 import software.amazon.awssdk.services.s3.model.S3Request;
 import software.amazon.encryption.s3.S3EncryptionClient;
@@ -230,7 +231,7 @@ public class KmsKeyring extends S3Keyring {
     }
 
     public static class Builder extends S3Keyring.Builder<KmsKeyring, Builder> {
-        private KmsClient _kmsClient = KmsClient.builder().build();
+        private KmsClient _kmsClient;
         private String _wrappingKeyId;
 
         private Builder() {
@@ -258,6 +259,10 @@ public class KmsKeyring extends S3Keyring {
         }
 
         public KmsKeyring build() {
+            if (_kmsClient == null) {
+                _kmsClient = KmsClient.create();
+            }
+
             return new KmsKeyring(this);
         }
     }

--- a/src/main/java/software/amazon/encryption/s3/materials/KmsKeyring.java
+++ b/src/main/java/software/amazon/encryption/s3/materials/KmsKeyring.java
@@ -14,7 +14,6 @@ import software.amazon.awssdk.services.kms.model.EncryptRequest;
 import software.amazon.awssdk.services.kms.model.EncryptResponse;
 import software.amazon.awssdk.services.kms.model.GenerateDataKeyRequest;
 import software.amazon.awssdk.services.kms.model.GenerateDataKeyResponse;
-import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.model.GetObjectRequest;
 import software.amazon.awssdk.services.s3.model.S3Request;
 import software.amazon.encryption.s3.S3EncryptionClient;


### PR DESCRIPTION
*Issue #, if available:*

- https://github.com/aws/amazon-s3-encryption-client-java/issues/183

*Description of changes:*

- Create `KmsClient` and `S3AsyncClient` only if not provided in Builder.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

# Check any applicable:
- [ ] Were any files moved? Moving files changes their URL, which breaks all hyperlinks to the files.
