### PR TITLE
chore: refactor to re-use existing S3Client to fetch instruction file

### DIFF
--- a/src/main/java/software/amazon/encryption/s3/internal/ContentMetadataDecodingStrategy.java
+++ b/src/main/java/software/amazon/encryption/s3/internal/ContentMetadataDecodingStrategy.java
@@ -2,10 +2,11 @@
 // SPDX-License-Identifier: Apache-2.0
 package software.amazon.encryption.s3.internal;
 
+import software.amazon.awssdk.services.s3.S3AsyncClient;
 import software.amazon.awssdk.services.s3.model.GetObjectRequest;
 import software.amazon.awssdk.services.s3.model.GetObjectResponse;
 
 @FunctionalInterface
 public interface ContentMetadataDecodingStrategy {
-    ContentMetadata decodeMetadata(GetObjectRequest request, GetObjectResponse response);
+    ContentMetadata decodeMetadata(GetObjectRequest request, GetObjectResponse response, S3AsyncClient s3AsyncClient);
 }

--- a/src/main/java/software/amazon/encryption/s3/internal/GetEncryptedObjectPipeline.java
+++ b/src/main/java/software/amazon/encryption/s3/internal/GetEncryptedObjectPipeline.java
@@ -117,7 +117,7 @@ public class GetEncryptedObjectPipeline {
         @Override
         public void onResponse(GetObjectResponse response) {
             getObjectResponse = response;
-            contentMetadata = ContentMetadataStrategy.decode(getObjectRequest, response);
+            contentMetadata = ContentMetadataStrategy.decode(getObjectRequest, response, _s3AsyncClient);
             materials = prepareMaterialsFromRequest(getObjectRequest, response, contentMetadata);
             wrappedAsyncResponseTransformer.onResponse(response);
         }

--- a/src/test/java/software/amazon/encryption/s3/internal/ContentMetadataStrategyTest.java
+++ b/src/test/java/software/amazon/encryption/s3/internal/ContentMetadataStrategyTest.java
@@ -52,7 +52,7 @@ public class ContentMetadataStrategyTest {
                 .contentIv(bytes)
                 .build();
 
-        ContentMetadata contentMetadata = ContentMetadataStrategy.decode(getObjectRequest, getObjectResponse);
+        ContentMetadata contentMetadata = ContentMetadataStrategy.decode(getObjectRequest, getObjectResponse, null);
         assertEquals(expectedContentMetadata.algorithmSuite(), contentMetadata.algorithmSuite());
         String actualContentIv = Arrays.toString(contentMetadata.contentIv());
         String expectedContentIv = Arrays.toString(expectedContentMetadata.contentIv());


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

- refactor to re-use existing S3Client to fetch instruction file

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

# Check any applicable:
- [ ] Were any files moved? Moving files changes their URL, which breaks all hyperlinks to the files.
