### PR TITLE
fix: do not signal onComplete when the incoming buffer length is less than the cipher block

### DIFF
--- a/src/main/java/software/amazon/encryption/s3/internal/CipherSubscriber.java
+++ b/src/main/java/software/amazon/encryption/s3/internal/CipherSubscriber.java
@@ -51,7 +51,7 @@ public class CipherSubscriber implements Subscriber<ByteBuffer> {
             byte[] buf = BinaryUtils.copyBytesFrom(byteBuffer, amountToReadFromByteBuffer);
             outputBuffer = cipher.update(buf, 0, amountToReadFromByteBuffer);
             if (outputBuffer == null && amountToReadFromByteBuffer < cipher.getBlockSize()) {
-                // The underlying data is too short to fill in the block cipher
+                System.out.println("EARLY COMPLETE!");
                 // This is true at the end of the file, so complete to get the final
                 // bytes
                 this.onComplete();

--- a/src/main/java/software/amazon/encryption/s3/internal/CipherSubscriber.java
+++ b/src/main/java/software/amazon/encryption/s3/internal/CipherSubscriber.java
@@ -50,13 +50,21 @@ public class CipherSubscriber implements Subscriber<ByteBuffer> {
         if (amountToReadFromByteBuffer > 0) {
             byte[] buf = BinaryUtils.copyBytesFrom(byteBuffer, amountToReadFromByteBuffer);
             outputBuffer = cipher.update(buf, 0, amountToReadFromByteBuffer);
-            if (outputBuffer == null && amountToReadFromByteBuffer < cipher.getBlockSize()) {
-                System.out.println("EARLY COMPLETE!");
-                // This is true at the end of the file, so complete to get the final
-                // bytes
-                this.onComplete();
+            if (outputBuffer == null || outputBuffer.length == 0) {
+                // The underlying data is too short to fill in the block cipher.
+                // Note that while the JCE Javadoc specifies that the outputBuffer is null in this case,
+                // in practice SunJCE and ACCP return an empty buffer instead, hence checks for
+                // null OR length == 0.
+                if (contentRead.get() == contentLength) {
+                    // All content has been read, so complete to get the final bytes
+                    this.onComplete();
+                }
+                // Otherwise, wait for more bytes. To avoid blocking,
+                // send an empty buffer to the wrapped subscriber.
+                wrappedSubscriber.onNext(ByteBuffer.allocate(0));
+            } else {
+                wrappedSubscriber.onNext(ByteBuffer.wrap(outputBuffer));
             }
-            wrappedSubscriber.onNext(ByteBuffer.wrap(outputBuffer));
         } else {
             // Do nothing
             wrappedSubscriber.onNext(byteBuffer);

--- a/src/test/java/software/amazon/encryption/s3/utils/TinyBufferAsyncRequestBody.java
+++ b/src/test/java/software/amazon/encryption/s3/utils/TinyBufferAsyncRequestBody.java
@@ -1,0 +1,31 @@
+package software.amazon.encryption.s3.utils;
+
+import org.reactivestreams.Subscriber;
+import software.amazon.awssdk.core.async.AsyncRequestBody;
+
+import java.nio.ByteBuffer;
+import java.util.Optional;
+
+/**
+ * AsyncRequestBody which wraps another AsyncRequestBody with a {@link TinyBufferSubscriber}.
+ * This is useful for testing poor network conditions where buffers may not be larger than
+ * the cipher's block size.
+ */
+public class TinyBufferAsyncRequestBody implements AsyncRequestBody {
+
+    private final AsyncRequestBody wrappedAsyncRequestBody;
+
+    public TinyBufferAsyncRequestBody(final AsyncRequestBody wrappedRequestBody) {
+        wrappedAsyncRequestBody = wrappedRequestBody;
+    }
+
+    @Override
+    public Optional<Long> contentLength() {
+        return wrappedAsyncRequestBody.contentLength();
+    }
+
+    @Override
+    public void subscribe(Subscriber<? super ByteBuffer> s) {
+        wrappedAsyncRequestBody.subscribe(new TinyBufferSubscriber(s));
+    }
+}

--- a/src/test/java/software/amazon/encryption/s3/utils/TinyBufferSubscriber.java
+++ b/src/test/java/software/amazon/encryption/s3/utils/TinyBufferSubscriber.java
@@ -1,0 +1,55 @@
+package software.amazon.encryption.s3.utils;
+
+import org.reactivestreams.Subscriber;
+import org.reactivestreams.Subscription;
+import software.amazon.awssdk.utils.BinaryUtils;
+
+import java.nio.ByteBuffer;
+
+/**
+ * Subscriber which purposefully limits the size of buffers sent to
+ * the wrapped subscriber. This is useful for simulating adverse network conditions.
+ */
+public class TinyBufferSubscriber implements Subscriber<ByteBuffer> {
+
+    private final Subscriber<? super ByteBuffer> wrappedSubscriber;
+
+    public TinyBufferSubscriber(final Subscriber wrappedSubscriber){
+        this.wrappedSubscriber =  wrappedSubscriber;
+    }
+
+    @Override
+    public void onSubscribe(Subscription s) {
+        wrappedSubscriber.onSubscribe(s);
+    }
+
+    @Override
+    public void onNext(ByteBuffer b) {
+        int i = 0;
+        // any value below GCM block size works
+        int chunkSize = 5;
+        while (b.remaining() > chunkSize) {
+            ByteBuffer tb = b.slice();
+            tb.limit(chunkSize);
+            byte[] intermediateBuf = BinaryUtils.copyBytesFrom(tb, chunkSize);
+            b.position(i + chunkSize);
+            i += chunkSize;
+            wrappedSubscriber.onNext(ByteBuffer.wrap(intermediateBuf));
+        }
+        // send the rest of the bytes
+        ByteBuffer sb = b.slice();
+        sb.limit(b.remaining());
+        byte[] intermedBuf = BinaryUtils.copyBytesFrom(sb, chunkSize);
+        wrappedSubscriber.onNext(ByteBuffer.wrap(intermedBuf));
+    }
+
+    @Override
+    public void onError(Throwable t) {
+        wrappedSubscriber.onError(t);
+    }
+
+    @Override
+    public void onComplete() {
+        wrappedSubscriber.onComplete();
+    }
+}


### PR DESCRIPTION
*Issue #, if available:* https://github.com/aws/amazon-s3-encryption-client-java/issues/185

*Description of changes:* The current implementation of the `CipherSubscriber` incorrectly assumes that the incoming `ByteBuffer` will only contain fewer bytes than the block cipher when it is the final block. In fact, the incoming `ByteBuffer` could have fewer bytes in cases where e.g. the networking conditions are poor. As a result, the `CipherSubscriber` may erroneously call `onComplete()` partway through the operation, which then fails due to contentLength mismatch. Additionally, as pointed out in https://github.com/aws/amazon-s3-encryption-client-java/issues/185, the `CipherSubscriber` may instead throw a NPE when `amountToReadFromByteBuffer` is greater than the block size. 

This PR fixes both bugs by instead checking if the `contentRead` is equal to `contentLength` before signaling `onComplete`. If the data has not been fully read, then the `CipherSubscriber` passes an empty array to avoid blocking such that subsequent `onNext()` invocations will fill up the cipher's underlying buffer until it has enough bytes to process a full block. 

Also, adds a test which was failing before this change. It requires specifying BouncyCastle as the JCE Provider as other providers (SunJCE, ACCP) return empty buffers instead of `null`. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

# Check any applicable:
- [ ] Were any files moved? Moving files changes their URL, which breaks all hyperlinks to the files.
