### PR TITLE
chore: add support policy

### DIFF
--- a/SUPPORT_POLICY.rst
+++ b/SUPPORT_POLICY.rst
@@ -2,7 +2,7 @@ Overview
 ========
 This page describes the support policy for the Amazon S3 Encryption Client. We regularly provide the Amazon S3 Encryption Client with updates that may contain support for new or updated APIs, new features, enhancements, bug fixes, security patches, or documentation updates. Updates may also address changes with dependencies, language runtimes, and operating systems.
 
-We recommend users to stay up-to-date with Encryption SDK releases to keep up with the latest features, security updates, and underlying dependencies. Continued use of an unsupported SDK version is not recommended and is done at the user’s discretion
+We recommend users to stay up-to-date with Amazon S3 Encryption Client releases to keep up with the latest features, security updates, and underlying dependencies. Continued use of an unsupported client version is not recommended and is done at the user’s discretion
 
 
 Major Version Lifecycle

--- a/SUPPORT_POLICY.rst
+++ b/SUPPORT_POLICY.rst
@@ -1,0 +1,37 @@
+Overview
+========
+This page describes the support policy for the Amazon S3 Encryption Client. We regularly provide the Amazon S3 Encryption Client with updates that may contain support for new or updated APIs, new features, enhancements, bug fixes, security patches, or documentation updates. Updates may also address changes with dependencies, language runtimes, and operating systems.
+
+We recommend users to stay up-to-date with Encryption SDK releases to keep up with the latest features, security updates, and underlying dependencies. Continued use of an unsupported SDK version is not recommended and is done at the user’s discretion
+
+
+Major Version Lifecycle
+========================
+The Amazon S3 Encryption Client follows the same major version lifecycle as the AWS SDK. For details on this lifecycle, see  `AWS SDKs and Tools Maintenance Policy`_.
+
+Version Support Matrix
+======================
+This table describes the current support status of each major version of the Amazon S3 Encryption Client for Java. It also shows the next status each major version will transition to, and the date at which that transition will happen.
+
+.. list-table::
+    :widths: 30 50 50 50
+    :header-rows: 1
+
+    * - Major version
+      - Current status
+      - Next status
+      - Next status date
+    * - 1.x
+      - End of Support
+      -
+      -
+    * - 2.x
+      - Maintenance Mode
+      - End of Support
+      - EOY 2025
+    * - 3.x
+      - Generally Available
+      -
+      -
+
+.. _AWS SDKs and Tools Maintenance Policy: https://docs.aws.amazon.com/sdkref/latest/guide/maint-policy.html#version-life-cycle


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* S3EC Java v3 is missing a support policy. Note that the v1/v2 clients are part of the AWS SDK for Java v1, which is now in maintenance mode and will be moving to end of support at the end of 2025: https://aws.amazon.com/blogs/developer/announcing-end-of-support-for-aws-sdk-for-java-v1-x-on-december-31-2025/. 


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

# Check any applicable:
- [ ] Were any files moved? Moving files changes their URL, which breaks all hyperlinks to the files.
