### PR TITLE
chore: set bufferSize to 1 when bufferSize is less than or equal to 0 is in BoundedStreamBufferer

### DIFF
--- a/src/test/java/software/amazon/encryption/s3/utils/BoundedStreamBufferer.java
+++ b/src/test/java/software/amazon/encryption/s3/utils/BoundedStreamBufferer.java
@@ -12,6 +12,11 @@ import java.io.InputStream;
 public class BoundedStreamBufferer {
 
     public static byte[] toByteArray(InputStream is, int bufferSize) throws IOException {
+        if (bufferSize <= 0) {
+            // buffer size cannot be zero,
+            // set it to 1 instead.
+            bufferSize = 1;
+        }
         try (ByteArrayOutputStream output = new ByteArrayOutputStream()) {
             byte[] b = new byte[bufferSize];
             int n;
@@ -23,6 +28,11 @@ public class BoundedStreamBufferer {
     }
 
     public static byte[] toByteArrayWithMarkReset(InputStream is, int bufferSize) throws IOException {
+        if (bufferSize <= 0) {
+            // buffer size cannot be zero,
+            // set it to 1 instead.
+            bufferSize = 1;
+        }
         try (ByteArrayOutputStream output = new ByteArrayOutputStream()) {
             byte[] b = new byte[bufferSize];
             // burn some bytes to force mark/reset


### PR DESCRIPTION
*Issue #, if available:* 

No issue, but see https://github.com/aws/amazon-s3-encryption-client-java/actions/runs/9288503510/job/25560124190 for failed CI run 

*Description of changes:* 

When the `inputLength` in the stream tests is equal or less than 8, the `bufferSize` parameter gets set to 0 which, due to how the InputStreamSubscriber is implemented, becomes an AssertionError later on.

The easiest fix is to set the the bufferSize to 1 in BoundedStreamBufferer; this retains the spirit of the utility, which is to read the stream chunk by chunk such that the entire stream isn't read all at once.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

# Check any applicable:
- [ ] Were any files moved? Moving files changes their URL, which breaks all hyperlinks to the files.
