### PR TITLE
feat: allow S3EncryptionClient and S3AsyncEncryption Client to be configured

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -46,6 +46,8 @@ jobs:
 
       - name: Test
         run: |
+          export AWS_S3EC_TEST_ALT_KMS_KEY_ARN=arn:aws:kms:${{ vars.CI_AWS_REGION }}:${{ secrets.CI_AWS_ACCOUNT_ID }}:key/${{ vars.CI_ALT_KMS_KEY_ID }}
+          export AWS_S3EC_TEST_ALT_ROLE_ARN=arn:aws:iam::${{ secrets.CI_AWS_ACCOUNT_ID }}:role/service-role/${{ CI_ALT_ROLE }}
           export AWS_S3EC_TEST_BUCKET=${{ vars.CI_S3_BUCKET }}
           export AWS_S3EC_TEST_KMS_KEY_ID=arn:aws:kms:${{ vars.CI_AWS_REGION }}:${{ secrets.CI_AWS_ACCOUNT_ID }}:key/${{ vars.CI_KMS_KEY_ID }}
           export AWS_S3EC_TEST_KMS_KEY_ALIAS=arn:aws:kms:${{ vars.CI_AWS_REGION }}:${{ secrets.CI_AWS_ACCOUNT_ID }}:alias/${{ vars.CI_KMS_KEY_ALIAS }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -47,7 +47,7 @@ jobs:
       - name: Test
         run: |
           export AWS_S3EC_TEST_ALT_KMS_KEY_ARN=arn:aws:kms:${{ vars.CI_AWS_REGION }}:${{ secrets.CI_AWS_ACCOUNT_ID }}:key/${{ vars.CI_ALT_KMS_KEY_ID }}
-          export AWS_S3EC_TEST_ALT_ROLE_ARN=arn:aws:iam::${{ secrets.CI_AWS_ACCOUNT_ID }}:role/service-role/${{ CI_ALT_ROLE }}
+          export AWS_S3EC_TEST_ALT_ROLE_ARN=arn:aws:iam::${{ secrets.CI_AWS_ACCOUNT_ID }}:role/service-role/${{ vars.CI_ALT_ROLE }}
           export AWS_S3EC_TEST_BUCKET=${{ vars.CI_S3_BUCKET }}
           export AWS_S3EC_TEST_KMS_KEY_ID=arn:aws:kms:${{ vars.CI_AWS_REGION }}:${{ secrets.CI_AWS_ACCOUNT_ID }}:key/${{ vars.CI_KMS_KEY_ID }}
           export AWS_S3EC_TEST_KMS_KEY_ALIAS=arn:aws:kms:${{ vars.CI_AWS_REGION }}:${{ secrets.CI_AWS_ACCOUNT_ID }}:alias/${{ vars.CI_KMS_KEY_ALIAS }}

--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@ The other values are added as variables (by clicking the "New repository variabl
 * `CI_S3_BUCKET` - the S3 bucket to use, e.g. s3ec-github-test-bucket.
 * `CI_KMS_KEY_ID` - the short KMS key ID to use, e.g. c3eafb5f-e87d-4584-9400-cf419ce5d782.
 * `CI_KMS_KEY_ALIAS` - the KMS key alias to use, e.g. S3EC-Github-KMS-Key. Note that the alias must reference the key ID above.
+* `CI_ALT_ROLE` - an alternate role to use that is different from the role defined above. It must have permission to use the KMS key below and the S3 bucket above.
+* `CI_ALT_KMS_KEY_ID`- the KMS key of an alternate KMS key to use. The alternate role must have access to use the key and the role for `CI_AWS_ROLE` must not have access to the key.
 
 ## Migration
 
@@ -43,6 +45,12 @@ The list of legacy modes and operations is provided below.
 However, this version does not support V2's Unencrypted Object Passthrough.
 This library can only read encrypted objects from S3,
 unencrypted objects MUST be read with the base S3 Client.
+
+## Client Configuration
+
+The S3 Encryption Client uses "wrapped" clients to make its requests to S3 and/or KMS.
+You can configure each client independently, or apply a "top-level" configuration which is applied to all wrapped clients.
+Refer to the Client Configuration Example in the [Examples directory](https://github.com/aws/amazon-s3-encryption-client-java/tree/main/src/examples/java/software/amazon/encryption/s3/examples) for examples of each configuration method.
 
 ### Examples
 #### V2 KMS Materials Provider to V3

--- a/cfn/S3EC-GitHub-CF-Template.yml
+++ b/cfn/S3EC-GitHub-CF-Template.yml
@@ -14,6 +14,20 @@ Resources:
             Action: 'kms:*'
             Resource: '*'
 
+  S3ECGitHubKMSKeyIDAlternate:
+    Type: 'AWS::KMS::Key'
+    Properties:
+      Description: Alternate KMS Key for GitHub Action Workflow
+      Enabled: true
+      KeyPolicy:
+        Version: 2012-10-17
+        Statement:
+          - Effect: Allow
+            Principal:
+              AWS: !Sub 'arn:aws:iam::${AWS::AccountId}:root'
+            Action: 'kms:*'
+            Resource: '*'
+
   S3ECGitHubKMSKeyAlias:
     Type: 'AWS::KMS::Alias'
     Properties:
@@ -73,6 +87,28 @@ Resources:
         }
       ManagedPolicyName: S3EC-GitHub-KMS-Key-Policy
 
+  S3ECGitHubKMSKeyPolicyAlternate:
+    Type: 'AWS::IAM::ManagedPolicy'
+    Properties:
+      PolicyDocument: !Sub |
+        {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Effect": "Allow",
+              "Resource": [
+                "arn:aws:kms:*:${AWS::AccountId}:key/${S3ECGitHubKMSKeyIDAlternate}"
+              ],
+              "Action": [
+                "kms:Decrypt",
+                "kms:GenerateDataKey",
+                "kms:GenerateDataKeyPair"
+              ]
+            }
+          ]
+        }
+      ManagedPolicyName: S3EC-GitHub-KMS-Key-Policy-Alternate
+
   S3ECGithubTestRole:
     Type: 'AWS::IAM::Role'
     Properties:
@@ -107,4 +143,40 @@ Resources:
         for testing
       ManagedPolicyArns:
         - !Ref S3ECGitHubKMSKeyPolicy
+        - !Ref S3ECGitHubS3BucketPolicy
+
+  S3ECGithubTestRoleAlternate:
+    Type: 'AWS::IAM::Role'
+    Properties:
+      Path: /service-role/
+      RoleName: S3EC-GitHub-test-role-alternate
+      AssumeRolePolicyDocument: !Sub |
+        {
+          "Version": "2012-10-17",   
+          "Statement": [
+            {
+              "Effect": "Allow",
+              "Principal": { "Federated": "arn:aws:iam::${AWS::AccountId}:oidc-provider/token.actions.githubusercontent.com" },
+              "Action": "sts:AssumeRoleWithWebIdentity",
+              "Condition": {
+                  "StringEquals": {
+                    "token.actions.githubusercontent.com:aud": "sts.amazonaws.com"
+                  },
+                  "StringLike": {
+                    "token.actions.githubusercontent.com:sub": "repo:aws/amazon-s3-encryption-client-java:*"
+                  }
+               }
+            },
+            {
+              "Effect": "Allow",
+              "Principal": { "AWS": "arn:aws:iam::${AWS::AccountId}:role/ToolsDevelopment" },
+              "Action": "sts:AssumeRole"
+            }
+          ]
+        }
+      Description: >-
+        Grant GitHub S3 put and get and KMS (alt key) encrypt, decrypt, and generate access
+        for testing
+      ManagedPolicyArns:
+        - !Ref S3ECGitHubKMSKeyPolicyAlternate
         - !Ref S3ECGitHubS3BucketPolicy

--- a/cfn/S3EC-GitHub-CF-Template.yml
+++ b/cfn/S3EC-GitHub-CF-Template.yml
@@ -109,6 +109,67 @@ Resources:
         }
       ManagedPolicyName: S3EC-GitHub-KMS-Key-Policy-Alternate
 
+  S3ECGithubTestRoleAlternate:
+    Type: 'AWS::IAM::Role'
+    Properties:
+      Path: /service-role/
+      RoleName: S3EC-GitHub-test-role-alternate
+      AssumeRolePolicyDocument: !Sub |
+        {
+          "Version": "2012-10-17",   
+          "Statement": [
+            {
+              "Effect": "Allow",
+              "Principal": { "Federated": "arn:aws:iam::${AWS::AccountId}:oidc-provider/token.actions.githubusercontent.com" },
+              "Action": "sts:AssumeRoleWithWebIdentity",
+              "Condition": {
+                  "StringEquals": {
+                    "token.actions.githubusercontent.com:aud": "sts.amazonaws.com"
+                  },
+                  "StringLike": {
+                    "token.actions.githubusercontent.com:sub": "repo:aws/amazon-s3-encryption-client-java:*"
+                  }
+               }
+            },
+            {
+              "Effect": "Allow",
+              "Principal": { "AWS": "arn:aws:iam::${AWS::AccountId}:role/ToolsDevelopment" },
+              "Action": "sts:AssumeRole"
+            },
+            {
+              "Effect": "Allow",
+              "Principal": { "AWS": "arn:aws:iam::${AWS::AccountId}:role/service-role/S3EC-GitHub-test-role" },
+              "Action": "sts:AssumeRole"
+            }
+          ]
+        }
+      Description: >-
+        Grant GitHub S3 put and get and KMS (alt key) encrypt, decrypt, and generate access
+        for testing
+      ManagedPolicyArns:
+        - !Ref S3ECGitHubKMSKeyPolicyAlternate
+        - !Ref S3ECGitHubS3BucketPolicy
+
+  S3ECGitHubAssumeAlternatePolicy:
+    Type: 'AWS::IAM::ManagedPolicy'
+    Properties:
+      PolicyDocument: !Sub |
+        {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Effect": "Allow",
+              "Resource": [
+                "arn:aws:iam::${AWS::AccountId}:role/service-role/${S3ECGithubTestRoleAlternate}"
+              ],
+              "Action": [
+                "sts:AssumeRole"
+              ]
+            }
+          ]
+        }
+      ManagedPolicyName: S3EC-GitHub-Assume-Alternate-Policy
+
   S3ECGithubTestRole:
     Type: 'AWS::IAM::Role'
     Properties:
@@ -144,39 +205,6 @@ Resources:
       ManagedPolicyArns:
         - !Ref S3ECGitHubKMSKeyPolicy
         - !Ref S3ECGitHubS3BucketPolicy
+        - !Ref S3ECGitHubAssumeAlternatePolicy
 
-  S3ECGithubTestRoleAlternate:
-    Type: 'AWS::IAM::Role'
-    Properties:
-      Path: /service-role/
-      RoleName: S3EC-GitHub-test-role-alternate
-      AssumeRolePolicyDocument: !Sub |
-        {
-          "Version": "2012-10-17",   
-          "Statement": [
-            {
-              "Effect": "Allow",
-              "Principal": { "Federated": "arn:aws:iam::${AWS::AccountId}:oidc-provider/token.actions.githubusercontent.com" },
-              "Action": "sts:AssumeRoleWithWebIdentity",
-              "Condition": {
-                  "StringEquals": {
-                    "token.actions.githubusercontent.com:aud": "sts.amazonaws.com"
-                  },
-                  "StringLike": {
-                    "token.actions.githubusercontent.com:sub": "repo:aws/amazon-s3-encryption-client-java:*"
-                  }
-               }
-            },
-            {
-              "Effect": "Allow",
-              "Principal": { "AWS": "arn:aws:iam::${AWS::AccountId}:role/ToolsDevelopment" },
-              "Action": "sts:AssumeRole"
-            }
-          ]
-        }
-      Description: >-
-        Grant GitHub S3 put and get and KMS (alt key) encrypt, decrypt, and generate access
-        for testing
-      ManagedPolicyArns:
-        - !Ref S3ECGitHubKMSKeyPolicyAlternate
-        - !Ref S3ECGitHubS3BucketPolicy
+

--- a/pom.xml
+++ b/pom.xml
@@ -155,6 +155,14 @@
       <scope>test</scope>
     </dependency>
 
+    <dependency>
+      <groupId>software.amazon.awssdk</groupId>
+      <artifactId>sts</artifactId>
+      <version>2.20.38</version>
+      <optional>true</optional>
+      <scope>test</scope>
+    </dependency>
+
   </dependencies>
 
   <build>

--- a/src/examples/java/software/amazon/encryption/s3/examples/AsyncClientExample.java
+++ b/src/examples/java/software/amazon/encryption/s3/examples/AsyncClientExample.java
@@ -1,9 +1,5 @@
 package software.amazon.encryption.s3.examples;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static software.amazon.encryption.s3.utils.S3EncryptionClientTestResources.KMS_KEY_ID;
-import static software.amazon.encryption.s3.utils.S3EncryptionClientTestResources.appendTestSuffix;
-
 import software.amazon.awssdk.core.ResponseBytes;
 import software.amazon.awssdk.core.async.AsyncRequestBody;
 import software.amazon.awssdk.core.async.AsyncResponseTransformer;
@@ -13,6 +9,10 @@ import software.amazon.awssdk.services.s3.model.PutObjectResponse;
 import software.amazon.encryption.s3.S3AsyncEncryptionClient;
 
 import java.util.concurrent.CompletableFuture;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static software.amazon.encryption.s3.utils.S3EncryptionClientTestResources.KMS_KEY_ID;
+import static software.amazon.encryption.s3.utils.S3EncryptionClientTestResources.appendTestSuffix;
 
 public class AsyncClientExample {
     public static final String OBJECT_KEY = appendTestSuffix("async-client-example");
@@ -33,7 +33,7 @@ public class AsyncClientExample {
         final String input = "PutAsyncGetAsync";
 
         // Instantiate the S3 Async Encryption Client to encrypt and decrypt
-        // by specifying an AES Key with the aesKey builder parameter.
+        // by specifying a KMS key with the kmsKeyId parameter.
         //
         // This means that the S3 Async Encryption Client can perform both encrypt and decrypt operations
         // as part of the S3 putObject and getObject operations.

--- a/src/examples/java/software/amazon/encryption/s3/examples/ClientConfigurationExample.java
+++ b/src/examples/java/software/amazon/encryption/s3/examples/ClientConfigurationExample.java
@@ -43,49 +43,49 @@ public class ClientConfigurationExample {
     // Instantiate the wrapped S3 client with the default credentials
     // and the region to use with S3.
     final S3Client wrappedClient = S3Client.builder()
-      .credentialsProvider(defaultCreds)
-      .region(Region.of(S3_REGION.toString()))
-      .build();
+            .credentialsProvider(defaultCreds)
+            .region(Region.of(S3_REGION.toString()))
+            .build();
 
     // Instantiate the wrapped Async S3 client with the default credentials
     // and the region to use with S3.
     final S3AsyncClient wrappedAsyncClient = S3AsyncClient.builder()
-      .credentialsProvider(defaultCreds)
-      .region(Region.of(S3_REGION.toString()))
-      .build();
+            .credentialsProvider(defaultCreds)
+            .region(Region.of(S3_REGION.toString()))
+            .build();
 
     // Instantiate the KMS client with alternate credentials.
     // This client will be used for all KMS requests.
     final KmsClient kmsClient = KmsClient.builder()
-      .credentialsProvider(altCreds)
-      .region(Region.of(KMS_REGION.toString()))
-      .build();
+            .credentialsProvider(altCreds)
+            .region(Region.of(KMS_REGION.toString()))
+            .build();
 
     // Instantiate a KMS Keyring to use with the S3 Encryption Client.
     final KmsKeyring kmsKeyring = KmsKeyring.builder()
-      .wrappingKeyId(ALTERNATE_KMS_KEY)
-      .kmsClient(kmsClient)
-      .build();
+            .wrappingKeyId(ALTERNATE_KMS_KEY)
+            .kmsClient(kmsClient)
+            .build();
 
     // Instantiate the S3 Encryption Client using the configured clients and keyring.
     final S3Client s3Client = S3EncryptionClient.builder()
-      .wrappedClient(wrappedClient)
-      .wrappedAsyncClient(wrappedAsyncClient)
-      .keyring(kmsKeyring)
-      .build();
+            .wrappedClient(wrappedClient)
+            .wrappedAsyncClient(wrappedAsyncClient)
+            .keyring(kmsKeyring)
+            .build();
 
     // Use the client to call putObject.
     s3Client.putObject(builder -> builder
-        .bucket(BUCKET)
-        .key(objectKey)
-        .build(),
-      RequestBody.fromString(input));
+                    .bucket(BUCKET)
+                    .key(objectKey)
+                    .build(),
+            RequestBody.fromString(input));
 
     // Use the client to call getObject.
     ResponseBytes<GetObjectResponse> objectResponse = s3Client.getObjectAsBytes(builder -> builder
-      .bucket(BUCKET)
-      .key(objectKey)
-      .build());
+            .bucket(BUCKET)
+            .key(objectKey)
+            .build());
     String output = objectResponse.asUtf8String();
     // Check that the output matches the input.
     assertEquals(input, output);
@@ -110,23 +110,23 @@ public class ClientConfigurationExample {
     // By passing the creds into the credentialsProvider parameter,
     // the S3EC will use these creds for both S3 and KMS requests.
     final S3Client s3Client = S3EncryptionClient.builder()
-      .credentialsProvider(creds)
-      .region(Region.of(KMS_REGION.toString()))
-      .kmsKeyId(ALTERNATE_KMS_KEY)
-      .build();
+            .credentialsProvider(creds)
+            .region(Region.of(KMS_REGION.toString()))
+            .kmsKeyId(ALTERNATE_KMS_KEY)
+            .build();
 
     // Use the client to call putObject.
     s3Client.putObject(builder -> builder
-        .bucket(BUCKET)
-        .key(objectKey)
-        .build(),
-      RequestBody.fromString(input));
+                    .bucket(BUCKET)
+                    .key(objectKey)
+                    .build(),
+            RequestBody.fromString(input));
 
     // Use the client to call getObject.
     ResponseBytes<GetObjectResponse> objectResponse = s3Client.getObjectAsBytes(builder -> builder
-      .bucket(BUCKET)
-      .key(objectKey)
-      .build());
+            .bucket(BUCKET)
+            .key(objectKey)
+            .build());
     String output = objectResponse.asUtf8String();
     // Check that the output matches the input.
     assertEquals(input, output);

--- a/src/examples/java/software/amazon/encryption/s3/examples/ClientConfigurationExample.java
+++ b/src/examples/java/software/amazon/encryption/s3/examples/ClientConfigurationExample.java
@@ -1,0 +1,139 @@
+package software.amazon.encryption.s3.examples;
+
+import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
+import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
+import software.amazon.awssdk.core.ResponseBytes;
+import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.kms.KmsClient;
+import software.amazon.awssdk.services.s3.S3AsyncClient;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.GetObjectResponse;
+import software.amazon.encryption.s3.S3EncryptionClient;
+import software.amazon.encryption.s3.materials.KmsKeyring;
+import software.amazon.encryption.s3.utils.S3EncryptionClientTestResources;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static software.amazon.encryption.s3.utils.S3EncryptionClientTestResources.ALTERNATE_KMS_KEY;
+import static software.amazon.encryption.s3.utils.S3EncryptionClientTestResources.BUCKET;
+import static software.amazon.encryption.s3.utils.S3EncryptionClientTestResources.KMS_REGION;
+import static software.amazon.encryption.s3.utils.S3EncryptionClientTestResources.S3_REGION;
+import static software.amazon.encryption.s3.utils.S3EncryptionClientTestResources.appendTestSuffix;
+import static software.amazon.encryption.s3.utils.S3EncryptionClientTestResources.deleteObject;
+
+public class ClientConfigurationExample {
+
+  public static void main(String[] args) {
+    CustomClientConfiguration();
+    TopLevelClientConfiguration();
+  }
+
+  /**
+   * This example demonstrates how to use specific client configuration for
+   * the S3 and KMS clients used within the S3 Encryption Client.
+   */
+  public static void CustomClientConfiguration() {
+    final String objectKey = appendTestSuffix("custom-client-configuration-example");
+    final String input = "CustomClientConfigurationExample";
+    // Load your AWS credentials from an external source.
+    final AwsCredentialsProvider defaultCreds = DefaultCredentialsProvider.create();
+    // This example uses two different sets of credentials.
+    final AwsCredentialsProvider altCreds = new S3EncryptionClientTestResources.AlternateRoleCredentialsProvider();
+
+    // Instantiate the wrapped S3 client with the default credentials
+    // and the region to use with S3.
+    final S3Client wrappedClient = S3Client.builder()
+      .credentialsProvider(defaultCreds)
+      .region(Region.of(S3_REGION.toString()))
+      .build();
+
+    // Instantiate the wrapped Async S3 client with the default credentials
+    // and the region to use with S3.
+    final S3AsyncClient wrappedAsyncClient = S3AsyncClient.builder()
+      .credentialsProvider(defaultCreds)
+      .region(Region.of(S3_REGION.toString()))
+      .build();
+
+    // Instantiate the KMS client with alternate credentials.
+    // This client will be used for all KMS requests.
+    final KmsClient kmsClient = KmsClient.builder()
+      .credentialsProvider(altCreds)
+      .region(Region.of(KMS_REGION.toString()))
+      .build();
+
+    // Instantiate a KMS Keyring to use with the S3 Encryption Client.
+    final KmsKeyring kmsKeyring = KmsKeyring.builder()
+      .wrappingKeyId(ALTERNATE_KMS_KEY)
+      .kmsClient(kmsClient)
+      .build();
+
+    // Instantiate the S3 Encryption Client using the configured clients and keyring.
+    final S3Client s3Client = S3EncryptionClient.builder()
+      .wrappedClient(wrappedClient)
+      .wrappedAsyncClient(wrappedAsyncClient)
+      .keyring(kmsKeyring)
+      .build();
+
+    // Use the client to call putObject.
+    s3Client.putObject(builder -> builder
+        .bucket(BUCKET)
+        .key(objectKey)
+        .build(),
+      RequestBody.fromString(input));
+
+    // Use the client to call getObject.
+    ResponseBytes<GetObjectResponse> objectResponse = s3Client.getObjectAsBytes(builder -> builder
+      .bucket(BUCKET)
+      .key(objectKey)
+      .build());
+    String output = objectResponse.asUtf8String();
+    // Check that the output matches the input.
+    assertEquals(input, output);
+
+    // Delete the object.
+    deleteObject(BUCKET, objectKey, s3Client);
+    // Close the S3 Client.
+    s3Client.close();
+  }
+
+  /**
+   * This example demonstrates how to use a single client configuration for
+   * the S3 and KMS clients used within the S3 Encryption Client.
+   */
+  public static void TopLevelClientConfiguration() {
+    final String objectKey = appendTestSuffix("top-level-client-configuration-example");
+    final String input = "TopLevelClientConfigurationExample";
+    // Load your AWS credentials from an external source.
+    final AwsCredentialsProvider creds = new S3EncryptionClientTestResources.AlternateRoleCredentialsProvider();
+
+    // Instantiate the S3 Encryption Client via its builder.
+    // By passing the creds into the credentialsProvider parameter,
+    // the S3EC will use these creds for both S3 and KMS requests.
+    final S3Client s3Client = S3EncryptionClient.builder()
+      .credentialsProvider(creds)
+      .region(Region.of(KMS_REGION.toString()))
+      .kmsKeyId(ALTERNATE_KMS_KEY)
+      .build();
+
+    // Use the client to call putObject.
+    s3Client.putObject(builder -> builder
+        .bucket(BUCKET)
+        .key(objectKey)
+        .build(),
+      RequestBody.fromString(input));
+
+    // Use the client to call getObject.
+    ResponseBytes<GetObjectResponse> objectResponse = s3Client.getObjectAsBytes(builder -> builder
+      .bucket(BUCKET)
+      .key(objectKey)
+      .build());
+    String output = objectResponse.asUtf8String();
+    // Check that the output matches the input.
+    assertEquals(input, output);
+
+    // Delete the object.
+    deleteObject(BUCKET, objectKey, s3Client);
+    // Close the S3 Client.
+    s3Client.close();
+  }
+}

--- a/src/examples/java/software/amazon/encryption/s3/examples/ClientConfigurationExample.java
+++ b/src/examples/java/software/amazon/encryption/s3/examples/ClientConfigurationExample.java
@@ -3,29 +3,29 @@ package software.amazon.encryption.s3.examples;
 import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
 import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
 import software.amazon.awssdk.core.ResponseBytes;
+import software.amazon.awssdk.core.async.AsyncRequestBody;
+import software.amazon.awssdk.core.async.AsyncResponseTransformer;
 import software.amazon.awssdk.core.sync.RequestBody;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.kms.KmsClient;
 import software.amazon.awssdk.services.s3.S3AsyncClient;
 import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.model.GetObjectResponse;
+import software.amazon.encryption.s3.S3AsyncEncryptionClient;
 import software.amazon.encryption.s3.S3EncryptionClient;
 import software.amazon.encryption.s3.materials.KmsKeyring;
 import software.amazon.encryption.s3.utils.S3EncryptionClientTestResources;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static software.amazon.encryption.s3.utils.S3EncryptionClientTestResources.ALTERNATE_KMS_KEY;
-import static software.amazon.encryption.s3.utils.S3EncryptionClientTestResources.BUCKET;
-import static software.amazon.encryption.s3.utils.S3EncryptionClientTestResources.KMS_REGION;
-import static software.amazon.encryption.s3.utils.S3EncryptionClientTestResources.S3_REGION;
-import static software.amazon.encryption.s3.utils.S3EncryptionClientTestResources.appendTestSuffix;
-import static software.amazon.encryption.s3.utils.S3EncryptionClientTestResources.deleteObject;
+import static software.amazon.encryption.s3.utils.S3EncryptionClientTestResources.*;
 
 public class ClientConfigurationExample {
 
   public static void main(String[] args) {
     CustomClientConfiguration();
     TopLevelClientConfiguration();
+    CustomClientConfigurationAsync();
+    TopLevelClientConfigurationAsync();
   }
 
   /**
@@ -47,8 +47,14 @@ public class ClientConfigurationExample {
             .region(Region.of(S3_REGION.toString()))
             .build();
 
-    // Instantiate the wrapped Async S3 client with the default credentials
-    // and the region to use with S3.
+    /*
+     * Instantiate the wrapped Async S3 client with the default credentials
+     * and the region to use with S3.
+     * The default S3 Encryption Client uses the async client for
+     * operations requiring encryption or decryption.
+     * All other operations such as bucket-related operations use the default client,
+     * which is configured below.
+     */
     final S3AsyncClient wrappedAsyncClient = S3AsyncClient.builder()
             .credentialsProvider(defaultCreds)
             .region(Region.of(S3_REGION.toString()))
@@ -109,6 +115,9 @@ public class ClientConfigurationExample {
     // Instantiate the S3 Encryption Client via its builder.
     // By passing the creds into the credentialsProvider parameter,
     // the S3EC will use these creds for both S3 and KMS requests.
+    // NOTE: If you use both the "top-level" configuration AND
+    // custom configuration such as the above example, the custom client
+    // configuration will take precedence.
     final S3Client s3Client = S3EncryptionClient.builder()
             .credentialsProvider(creds)
             .region(Region.of(KMS_REGION.toString()))
@@ -127,6 +136,110 @@ public class ClientConfigurationExample {
             .bucket(BUCKET)
             .key(objectKey)
             .build());
+    String output = objectResponse.asUtf8String();
+    // Check that the output matches the input.
+    assertEquals(input, output);
+
+    // Delete the object.
+    deleteObject(BUCKET, objectKey, s3Client);
+    // Close the S3 Client.
+    s3Client.close();
+  }
+
+  /**
+   * This example demonstrates how to use specific client configuration for
+   * the S3 and KMS clients used within the S3 Async Encryption Client.
+   */
+  public static void CustomClientConfigurationAsync() {
+    final String objectKey = appendTestSuffix("custom-client-configuration-example-async");
+    final String input = "CustomClientConfigurationExample";
+    // Load your AWS credentials from an external source.
+    final AwsCredentialsProvider defaultCreds = DefaultCredentialsProvider.create();
+    // This example uses two different sets of credentials.
+    final AwsCredentialsProvider altCreds = new S3EncryptionClientTestResources.AlternateRoleCredentialsProvider();
+
+    // Instantiate the wrapped (async) S3 client with the default credentials
+    // and the region to use with S3.
+    final S3AsyncClient wrappedAsyncClient = S3AsyncClient.builder()
+            .credentialsProvider(defaultCreds)
+            .region(Region.of(S3_REGION.toString()))
+            .build();
+
+    // Instantiate the KMS client with alternate credentials.
+    // This client will be used for all KMS requests.
+    final KmsClient kmsClient = KmsClient.builder()
+            .credentialsProvider(altCreds)
+            .region(Region.of(KMS_REGION.toString()))
+            .build();
+
+    // Instantiate a KMS Keyring to use with the S3 Encryption Client.
+    final KmsKeyring kmsKeyring = KmsKeyring.builder()
+            .wrappingKeyId(ALTERNATE_KMS_KEY)
+            .kmsClient(kmsClient)
+            .build();
+
+    // Instantiate the S3 Async Encryption Client using the configured clients and keyring.
+    final S3AsyncClient s3Client = S3AsyncEncryptionClient.builder()
+            .wrappedClient(wrappedAsyncClient)
+            .keyring(kmsKeyring)
+            .build();
+
+    // Use the async client to call putObject and block on its response
+    s3Client.putObject(builder -> builder
+                    .bucket(BUCKET)
+                    .key(objectKey)
+                    .build(),
+            AsyncRequestBody.fromString(input)).join();
+
+    // Use the async client to call getObject and block on its response
+    ResponseBytes<GetObjectResponse> objectResponse = s3Client.getObject(builder -> builder
+            .bucket(BUCKET)
+            .key(objectKey)
+            .build(), AsyncResponseTransformer.toBytes()).join();
+    String output = objectResponse.asUtf8String();
+    // Check that the output matches the input.
+    assertEquals(input, output);
+
+    // Delete the object.
+    deleteObject(BUCKET, objectKey, s3Client);
+    // Close the S3 Client.
+    s3Client.close();
+  }
+
+  /**
+   * This example demonstrates how to use a single client configuration for
+   * the S3 and KMS clients used within the S3 Encryption Client.
+   */
+  public static void TopLevelClientConfigurationAsync() {
+    final String objectKey = appendTestSuffix("top-level-client-configuration-async-example");
+    final String input = "TopLevelClientConfigurationExample";
+    // Load your AWS credentials from an external source.
+    final AwsCredentialsProvider creds = new S3EncryptionClientTestResources.AlternateRoleCredentialsProvider();
+
+    // Instantiate the S3 Async Encryption Client via its builder.
+    // By passing the creds into the credentialsProvider parameter,
+    // the S3EC will use these creds for both S3 and KMS requests.
+    // NOTE: If you use both the "top-level" configuration AND
+    // custom configuration such as the above example, the custom client
+    // configuration will take precedence.
+    final S3AsyncClient s3Client = S3AsyncEncryptionClient.builder()
+            .credentialsProvider(creds)
+            .region(Region.of(KMS_REGION.toString()))
+            .kmsKeyId(ALTERNATE_KMS_KEY)
+            .build();
+
+    // Use the async client to call putObject and block on its response.
+    s3Client.putObject(builder -> builder
+                    .bucket(BUCKET)
+                    .key(objectKey)
+                    .build(),
+            AsyncRequestBody.fromString(input)).join();
+
+    // Use the async client to call getObject and block on its response.
+    ResponseBytes<GetObjectResponse> objectResponse = s3Client.getObject(builder -> builder
+            .bucket(BUCKET)
+            .key(objectKey)
+            .build(), AsyncResponseTransformer.toBytes()).join();
     String output = objectResponse.asUtf8String();
     // Check that the output matches the input.
     assertEquals(input, output);

--- a/src/examples/java/software/amazon/encryption/s3/examples/PartialKeyPairExample.java
+++ b/src/examples/java/software/amazon/encryption/s3/examples/PartialKeyPairExample.java
@@ -159,7 +159,7 @@ public class PartialKeyPairExample {
         s3ClientPrivateKeyOnly.close();
     }
 
-    public static void cleanup(final String bucket) {
+    private static void cleanup(final String bucket) {
         // The S3 Encryption client is not required when deleting encrypted
         // objects, use the S3 Client.
         final S3Client s3Client = S3Client.builder().build();

--- a/src/main/java/software/amazon/encryption/s3/S3AsyncEncryptionClient.java
+++ b/src/main/java/software/amazon/encryption/s3/S3AsyncEncryptionClient.java
@@ -652,7 +652,7 @@ public class S3AsyncEncryptionClient extends DelegatingS3AsyncClient {
                         .fipsEnabled(_fipsEnabled)
                         .overrideConfiguration(_overrideConfiguration)
                         .endpointOverride(_endpointOverride)
-                        .asyncConfiguration(_clientAsyncConfiguration)
+                        .asyncConfiguration(_clientAsyncConfiguration != null ? _clientAsyncConfiguration : ClientAsyncConfiguration.builder().build())
                         .httpClient(_sdkAsyncHttpClient)
                         .httpClientBuilder(_sdkAsyncHttpClientBuilder)
                         .build();

--- a/src/main/java/software/amazon/encryption/s3/S3AsyncEncryptionClient.java
+++ b/src/main/java/software/amazon/encryption/s3/S3AsyncEncryptionClient.java
@@ -14,6 +14,7 @@ import software.amazon.awssdk.core.client.config.ClientOverrideConfiguration;
 import software.amazon.awssdk.core.exception.SdkClientException;
 import software.amazon.awssdk.http.async.SdkAsyncHttpClient;
 import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.kms.KmsClient;
 import software.amazon.awssdk.services.s3.DelegatingS3AsyncClient;
 import software.amazon.awssdk.services.s3.S3AsyncClient;
 import software.amazon.awssdk.services.s3.internal.crt.S3CrtAsyncClient;
@@ -617,7 +618,14 @@ public class S3AsyncEncryptionClient extends DelegatingS3AsyncClient {
             }
 
             if (_wrappedClient == null) {
-                _wrappedClient = S3AsyncClient.create();
+                _wrappedClient = S3AsyncClient.builder()
+                  .credentialsProvider(_awsCredentialsProvider)
+                  .region(_region)
+                  .dualstackEnabled(_dualStackEnabled)
+                  .fipsEnabled(_fipsEnabled)
+                  .overrideConfiguration(_overrideConfiguration)
+                  .endpointOverride(_endpointOverride)
+                  .build();
             }
 
             if (_keyring == null) {
@@ -634,11 +642,20 @@ public class S3AsyncEncryptionClient extends DelegatingS3AsyncClient {
                             .secureRandom(_secureRandom)
                             .build();
                 } else if (_kmsKeyId != null) {
+                    KmsClient kmsClient = KmsClient.builder()
+                      .credentialsProvider(_awsCredentialsProvider)
+                      .region(_region)
+                      .dualstackEnabled(_dualStackEnabled)
+                      .fipsEnabled(_fipsEnabled)
+                      .overrideConfiguration(_overrideConfiguration)
+                      .build();
+
                     _keyring = KmsKeyring.builder()
-                            .wrappingKeyId(_kmsKeyId)
-                            .enableLegacyWrappingAlgorithms(_enableLegacyWrappingAlgorithms)
-                            .secureRandom(_secureRandom)
-                            .build();
+                      .kmsClient(kmsClient)
+                      .wrappingKeyId(_kmsKeyId)
+                      .enableLegacyWrappingAlgorithms(_enableLegacyWrappingAlgorithms)
+                      .secureRandom(_secureRandom)
+                      .build();
                 }
             }
 

--- a/src/main/java/software/amazon/encryption/s3/S3AsyncEncryptionClient.java
+++ b/src/main/java/software/amazon/encryption/s3/S3AsyncEncryptionClient.java
@@ -189,7 +189,7 @@ public class S3AsyncEncryptionClient extends DelegatingS3AsyncClient {
      */
     @Override
     public <T> CompletableFuture<T> getObject(GetObjectRequest getObjectRequest,
-                                                           AsyncResponseTransformer<GetObjectResponse, T> asyncResponseTransformer) {
+                                              AsyncResponseTransformer<GetObjectResponse, T> asyncResponseTransformer) {
         GetEncryptedObjectPipeline pipeline = GetEncryptedObjectPipeline.builder()
                 .s3AsyncClient(_wrappedClient)
                 .cryptoMaterialsManager(_cryptoMaterialsManager)
@@ -646,16 +646,16 @@ public class S3AsyncEncryptionClient extends DelegatingS3AsyncClient {
 
             if (_wrappedClient == null) {
                 _wrappedClient = S3AsyncClient.builder()
-                  .credentialsProvider(_awsCredentialsProvider)
-                  .region(_region)
-                  .dualstackEnabled(_dualStackEnabled)
-                  .fipsEnabled(_fipsEnabled)
-                  .overrideConfiguration(_overrideConfiguration)
-                  .endpointOverride(_endpointOverride)
-                  .asyncConfiguration(_clientAsyncConfiguration)
-                  .httpClient(_sdkAsyncHttpClient)
-                  .httpClientBuilder(_sdkAsyncHttpClientBuilder)
-                  .build();
+                        .credentialsProvider(_awsCredentialsProvider)
+                        .region(_region)
+                        .dualstackEnabled(_dualStackEnabled)
+                        .fipsEnabled(_fipsEnabled)
+                        .overrideConfiguration(_overrideConfiguration)
+                        .endpointOverride(_endpointOverride)
+                        .asyncConfiguration(_clientAsyncConfiguration)
+                        .httpClient(_sdkAsyncHttpClient)
+                        .httpClientBuilder(_sdkAsyncHttpClientBuilder)
+                        .build();
             }
 
             if (_keyring == null) {
@@ -673,19 +673,19 @@ public class S3AsyncEncryptionClient extends DelegatingS3AsyncClient {
                             .build();
                 } else if (_kmsKeyId != null) {
                     KmsClient kmsClient = KmsClient.builder()
-                      .credentialsProvider(_awsCredentialsProvider)
-                      .region(_region)
-                      .dualstackEnabled(_dualStackEnabled)
-                      .fipsEnabled(_fipsEnabled)
-                      .overrideConfiguration(_overrideConfiguration)
-                      .build();
+                            .credentialsProvider(_awsCredentialsProvider)
+                            .region(_region)
+                            .dualstackEnabled(_dualStackEnabled)
+                            .fipsEnabled(_fipsEnabled)
+                            .overrideConfiguration(_overrideConfiguration)
+                            .build();
 
                     _keyring = KmsKeyring.builder()
-                      .kmsClient(kmsClient)
-                      .wrappingKeyId(_kmsKeyId)
-                      .enableLegacyWrappingAlgorithms(_enableLegacyWrappingAlgorithms)
-                      .secureRandom(_secureRandom)
-                      .build();
+                            .kmsClient(kmsClient)
+                            .wrappingKeyId(_kmsKeyId)
+                            .enableLegacyWrappingAlgorithms(_enableLegacyWrappingAlgorithms)
+                            .secureRandom(_secureRandom)
+                            .build();
                 }
             }
 

--- a/src/main/java/software/amazon/encryption/s3/S3AsyncEncryptionClient.java
+++ b/src/main/java/software/amazon/encryption/s3/S3AsyncEncryptionClient.java
@@ -513,6 +513,7 @@ public class S3AsyncEncryptionClient extends DelegatingS3AsyncClient {
 
         /**
          * The credentials provider to use for all inner clients, including KMS, if a KMS key ID is provided.
+         * Note that if a wrapped client is configured, the wrapped client will take precedence over this option.
          * @param awsCredentialsProvider
          * @return
          */
@@ -523,6 +524,7 @@ public class S3AsyncEncryptionClient extends DelegatingS3AsyncClient {
 
         /**
          * The AWS region to use for all inner clients, including KMS, if a KMS key ID is provided.
+         * Note that if a wrapped client is configured, the wrapped client will take precedence over this option.
          * @param region
          * @return
          */
@@ -531,16 +533,49 @@ public class S3AsyncEncryptionClient extends DelegatingS3AsyncClient {
             return this;
         }
 
+        /**
+         * Configure whether the SDK should use the AWS dualstack endpoint.
+         *
+         * <p>If this is not specified, the SDK will attempt to determine whether the dualstack endpoint should be used
+         * automatically using the following logic:
+         * <ol>
+         *     <li>Check the 'aws.useDualstackEndpoint' system property for 'true' or 'false'.</li>
+         *     <li>Check the 'AWS_USE_DUALSTACK_ENDPOINT' environment variable for 'true' or 'false'.</li>
+         *     <li>Check the {user.home}/.aws/credentials and {user.home}/.aws/config files for the 'use_dualstack_endpoint'
+         *     property set to 'true' or 'false'.</li>
+         * </ol>
+         *
+         * <p>If the setting is not found in any of the locations above, 'false' will be used.
+         */
         public Builder dualstackEnabled(Boolean isDualStackEnabled) {
             _dualStackEnabled = isDualStackEnabled;
             return this;
         }
 
+        /**
+         * Configure whether the wrapped SDK clients should use the AWS FIPS endpoints.
+         * Note that this option only enables FIPS for the service endpoints which the SDK clients use,
+         * it does not enable FIPS for the S3EC itself. Use a FIPS-enabled CryptoProvider for full FIPS support.
+         *
+         * <p>If this is not specified, the SDK will attempt to determine whether the FIPS endpoint should be used
+         * automatically using the following logic:
+         * <ol>
+         *     <li>Check the 'aws.useFipsEndpoint' system property for 'true' or 'false'.</li>
+         *     <li>Check the 'AWS_USE_FIPS_ENDPOINT' environment variable for 'true' or 'false'.</li>
+         *     <li>Check the {user.home}/.aws/credentials and {user.home}/.aws/config files for the 'use_fips_endpoint'
+         *     property set to 'true' or 'false'.</li>
+         * </ol>
+         *
+         * <p>If the setting is not found in any of the locations above, 'false' will be used.
+         */
         public Builder fipsEnabled(Boolean isFipsEnabled) {
             _fipsEnabled = isFipsEnabled;
             return this;
         }
 
+        /**
+         * Specify overrides to the default SDK configuration that should be used for wrapped clients.
+         */
         public Builder overrideConfiguration(ClientOverrideConfiguration overrideConfiguration) {
             _overrideConfiguration = overrideConfiguration;
             return this;

--- a/src/main/java/software/amazon/encryption/s3/S3EncryptionClient.java
+++ b/src/main/java/software/amazon/encryption/s3/S3EncryptionClient.java
@@ -774,6 +774,7 @@ public class S3EncryptionClient extends DelegatingS3Client {
 
         /**
          * The credentials provider to use for all inner clients, including KMS, if a KMS key ID is provided.
+         * Note that if a wrapped client is configured, the wrapped client will take precedence over this option.
          * @param awsCredentialsProvider
          * @return
          */
@@ -794,18 +795,51 @@ public class S3EncryptionClient extends DelegatingS3Client {
             return this;
         }
 
+        /**
+         * Configure whether the SDK should use the AWS dualstack endpoint.
+         *
+         * <p>If this is not specified, the SDK will attempt to determine whether the dualstack endpoint should be used
+         * automatically using the following logic:
+         * <ol>
+         *     <li>Check the 'aws.useDualstackEndpoint' system property for 'true' or 'false'.</li>
+         *     <li>Check the 'AWS_USE_DUALSTACK_ENDPOINT' environment variable for 'true' or 'false'.</li>
+         *     <li>Check the {user.home}/.aws/credentials and {user.home}/.aws/config files for the 'use_dualstack_endpoint'
+         *     property set to 'true' or 'false'.</li>
+         * </ol>
+         *
+         * <p>If the setting is not found in any of the locations above, 'false' will be used.
+         */
         @Override
         public Builder dualstackEnabled(Boolean isDualStackEnabled) {
             _dualStackEnabled = isDualStackEnabled;
             return this;
         }
 
+        /**
+         * Configure whether the wrapped SDK clients should use the AWS FIPS endpoints.
+         * Note that this option only enables FIPS for the service endpoints which the SDK clients use,
+         * it does not enable FIPS for the S3EC itself. Use a FIPS-enabled CryptoProvider for full FIPS support.
+         *
+         * <p>If this is not specified, the SDK will attempt to determine whether the FIPS endpoint should be used
+         * automatically using the following logic:
+         * <ol>
+         *     <li>Check the 'aws.useFipsEndpoint' system property for 'true' or 'false'.</li>
+         *     <li>Check the 'AWS_USE_FIPS_ENDPOINT' environment variable for 'true' or 'false'.</li>
+         *     <li>Check the {user.home}/.aws/credentials and {user.home}/.aws/config files for the 'use_fips_endpoint'
+         *     property set to 'true' or 'false'.</li>
+         * </ol>
+         *
+         * <p>If the setting is not found in any of the locations above, 'false' will be used.
+         */
         @Override
         public Builder fipsEnabled(Boolean isFipsEnabled) {
             _fipsEnabled = isFipsEnabled;
             return this;
         }
 
+        /**
+         * Specify overrides to the default SDK configuration that should be used for clients created by this builder.
+         */
         @Override
         public Builder overrideConfiguration(ClientOverrideConfiguration overrideConfiguration) {
             _overrideConfiguration = overrideConfiguration;

--- a/src/main/java/software/amazon/encryption/s3/S3EncryptionClient.java
+++ b/src/main/java/software/amazon/encryption/s3/S3EncryptionClient.java
@@ -203,11 +203,11 @@ public class S3EncryptionClient extends DelegatingS3Client {
 
         try {
             CompletableFuture<PutObjectResponse> futurePut = pipeline.putObject(putObjectRequest,
-                AsyncRequestBody.fromInputStream(
-                    requestBody.contentStreamProvider().newStream(),
-                    requestBody.optionalContentLength().orElse(-1L),
-                    singleThreadExecutor
-                )
+                    AsyncRequestBody.fromInputStream(
+                            requestBody.contentStreamProvider().newStream(),
+                            requestBody.optionalContentLength().orElse(-1L),
+                            singleThreadExecutor
+                    )
             );
 
             PutObjectResponse response = futurePut.join();
@@ -862,24 +862,24 @@ public class S3EncryptionClient extends DelegatingS3Client {
 
             if (_wrappedClient == null) {
                 _wrappedClient = S3Client.builder()
-                  .credentialsProvider(_awsCredentialsProvider)
-                  .region(_region)
-                  .dualstackEnabled(_dualStackEnabled)
-                  .fipsEnabled(_fipsEnabled)
-                  .overrideConfiguration(_overrideConfiguration)
-                  .endpointOverride(_endpointOverride)
-                  .build();
+                        .credentialsProvider(_awsCredentialsProvider)
+                        .region(_region)
+                        .dualstackEnabled(_dualStackEnabled)
+                        .fipsEnabled(_fipsEnabled)
+                        .overrideConfiguration(_overrideConfiguration)
+                        .endpointOverride(_endpointOverride)
+                        .build();
             }
 
             if (_wrappedAsyncClient == null) {
                 _wrappedAsyncClient = S3AsyncClient.builder()
-                  .credentialsProvider(_awsCredentialsProvider)
-                  .region(_region)
-                  .dualstackEnabled(_dualStackEnabled)
-                  .fipsEnabled(_fipsEnabled)
-                  .overrideConfiguration(_overrideConfiguration)
-                  .endpointOverride(_endpointOverride)
-                  .build();
+                        .credentialsProvider(_awsCredentialsProvider)
+                        .region(_region)
+                        .dualstackEnabled(_dualStackEnabled)
+                        .fipsEnabled(_fipsEnabled)
+                        .overrideConfiguration(_overrideConfiguration)
+                        .endpointOverride(_endpointOverride)
+                        .build();
             }
 
             if (_keyring == null) {
@@ -897,12 +897,12 @@ public class S3EncryptionClient extends DelegatingS3Client {
                             .build();
                 } else if (_kmsKeyId != null) {
                     KmsClient kmsClient = KmsClient.builder()
-                      .credentialsProvider(_awsCredentialsProvider)
-                      .region(_region)
-                      .dualstackEnabled(_dualStackEnabled)
-                      .fipsEnabled(_fipsEnabled)
-                      .overrideConfiguration(_overrideConfiguration)
-                      .build();
+                            .credentialsProvider(_awsCredentialsProvider)
+                            .region(_region)
+                            .dualstackEnabled(_dualStackEnabled)
+                            .fipsEnabled(_fipsEnabled)
+                            .overrideConfiguration(_overrideConfiguration)
+                            .build();
 
                     _keyring = KmsKeyring.builder()
                             .kmsClient(kmsClient)

--- a/src/test/java/software/amazon/encryption/s3/S3AsyncEncryptionClientTest.java
+++ b/src/test/java/software/amazon/encryption/s3/S3AsyncEncryptionClientTest.java
@@ -24,7 +24,9 @@ import software.amazon.awssdk.core.async.AsyncRequestBody;
 import software.amazon.awssdk.core.async.AsyncResponseTransformer;
 import software.amazon.awssdk.core.sync.RequestBody;
 import software.amazon.awssdk.core.sync.ResponseTransformer;
+import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.kms.KmsClient;
+import software.amazon.awssdk.services.kms.model.KmsException;
 import software.amazon.awssdk.services.s3.S3AsyncClient;
 import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.model.CopyObjectResponse;
@@ -36,6 +38,7 @@ import software.amazon.awssdk.services.s3.model.PutObjectResponse;
 import software.amazon.awssdk.services.s3.model.S3Exception;
 import software.amazon.encryption.s3.materials.KmsKeyring;
 import software.amazon.encryption.s3.utils.BoundedInputStream;
+import software.amazon.encryption.s3.utils.S3EncryptionClientTestResources;
 import software.amazon.encryption.s3.utils.TinyBufferAsyncRequestBody;
 
 import javax.crypto.KeyGenerator;
@@ -54,10 +57,14 @@ import java.util.concurrent.Executors;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+import static software.amazon.encryption.s3.utils.S3EncryptionClientTestResources.ALTERNATE_KMS_KEY;
 import static software.amazon.encryption.s3.utils.S3EncryptionClientTestResources.BUCKET;
 import static software.amazon.encryption.s3.utils.S3EncryptionClientTestResources.KMS_KEY_ID;
+import static software.amazon.encryption.s3.utils.S3EncryptionClientTestResources.KMS_REGION;
 import static software.amazon.encryption.s3.utils.S3EncryptionClientTestResources.appendTestSuffix;
 import static software.amazon.encryption.s3.utils.S3EncryptionClientTestResources.deleteObject;
 
@@ -82,10 +89,12 @@ public class S3AsyncEncryptionClientTest {
         S3AsyncClient wrappedAsyncClient = S3AsyncClient
           .builder()
           .credentialsProvider(creds)
+          .region(Region.of(KMS_REGION.toString()))
           .build();
         KmsClient kmsClient = KmsClient
           .builder()
           .credentialsProvider(creds)
+          .region(Region.of(KMS_REGION.toString()))
           .build();
 
         KmsKeyring keyring = KmsKeyring
@@ -128,6 +137,7 @@ public class S3AsyncEncryptionClientTest {
 
         S3AsyncClient s3Client = S3AsyncEncryptionClient.builder()
           .credentialsProvider(creds)
+          .region(Region.of(KMS_REGION.toString()))
           .kmsKeyId(KMS_KEY_ID)
           .build();
 
@@ -151,6 +161,102 @@ public class S3AsyncEncryptionClientTest {
         s3Client.close();
     }
 
+    @Test
+    public void s3AsyncEncryptionClientTopLevelAlternateCredentials() {
+        final String objectKey = appendTestSuffix("wrapped-s3-async-client-with-top-level-credentials");
+        final String input = "S3EncryptionClientTopLevelAlternateCredsTest";
+
+        // use alternate creds
+        AwsCredentialsProvider creds = new S3EncryptionClientTestResources.AlternateRoleCredentialsProvider();
+
+        S3AsyncClient s3Client = S3AsyncEncryptionClient.builder()
+          .credentialsProvider(creds)
+          .region(Region.of(KMS_REGION.toString()))
+          .kmsKeyId(KMS_KEY_ID)
+          .build();
+
+        // using the original key fails
+        try {
+            s3Client.putObject(builder -> builder
+                .bucket(BUCKET)
+                .key(objectKey)
+                .build(),
+              AsyncRequestBody.fromString(input));
+            fail("expected exception");
+        } catch (S3EncryptionClientException exception) {
+            // expected
+            assertTrue(exception.getMessage().contains("is not authorized to perform"));
+            assertInstanceOf(KmsException.class, exception.getCause());
+        } finally {
+            s3Client.close();
+        }
+
+        // using the alternate key succeeds
+        S3Client s3ClientAltCreds = S3EncryptionClient.builder()
+          .credentialsProvider(creds)
+          .region(Region.of(KMS_REGION.toString()))
+          .kmsKeyId(ALTERNATE_KMS_KEY)
+          .build();
+
+        s3Client.putObject(builder -> builder
+            .bucket(BUCKET)
+            .key(objectKey)
+            .build(),
+          AsyncRequestBody.fromString(input));
+
+        ResponseBytes<GetObjectResponse> objectResponse = s3Client.getObject(builder -> builder
+          .bucket(BUCKET)
+          .key(objectKey)
+          .build(), AsyncResponseTransformer.toBytes()).join();
+        String output = objectResponse.asUtf8String();
+        assertEquals(input, output);
+
+        // Cleanup
+        deleteObject(BUCKET, objectKey, s3ClientAltCreds);
+        s3ClientAltCreds.close();
+    }
+
+    @Test
+    public void s3EncryptionClientMixedCredentials() {
+        final String objectKey = appendTestSuffix("wrapped-s3-client-with-mixed-credentials");
+        final String input = "S3EncryptionClientTopLevelAlternateCredsTest";
+
+        // use alternate creds for KMS,
+        // default for S3
+        AwsCredentialsProvider creds = new S3EncryptionClientTestResources.AlternateRoleCredentialsProvider();
+        KmsClient kmsClient = KmsClient.builder()
+          .credentialsProvider(creds)
+          .region(Region.of(KMS_REGION.toString()))
+          .build();
+        KmsKeyring kmsKeyring = KmsKeyring.builder()
+          .kmsClient(kmsClient)
+          .wrappingKeyId(ALTERNATE_KMS_KEY)
+          .build();
+
+        S3AsyncClient s3Client = S3AsyncEncryptionClient.builder()
+          .credentialsProvider(creds)
+          .region(Region.of(KMS_REGION.toString()))
+          .kmsKeyId(ALTERNATE_KMS_KEY)
+          .build();
+
+        s3Client.putObject(builder -> builder
+            .bucket(BUCKET)
+            .key(objectKey)
+            .build(),
+          AsyncRequestBody.fromString(input));
+
+        ResponseBytes<GetObjectResponse> objectResponse = s3Client.getObject(builder -> builder
+          .bucket(BUCKET)
+          .key(objectKey)
+          .build(), AsyncResponseTransformer.toBytes()).join();
+        String output = objectResponse.asUtf8String();
+        assertEquals(input, output);
+
+        // Cleanup
+        deleteObject(BUCKET, objectKey, s3Client);
+        s3Client.close();
+        kmsClient.close();
+    }
     @Test
     public void putAsyncGetDefault() {
         final String objectKey = appendTestSuffix("put-async-get-default");

--- a/src/test/java/software/amazon/encryption/s3/S3AsyncEncryptionClientTest.java
+++ b/src/test/java/software/amazon/encryption/s3/S3AsyncEncryptionClientTest.java
@@ -87,38 +87,38 @@ public class S3AsyncEncryptionClientTest {
         AwsCredentialsProvider creds = DefaultCredentialsProvider.create();
 
         S3AsyncClient wrappedAsyncClient = S3AsyncClient
-          .builder()
-          .credentialsProvider(creds)
-          .region(Region.of(KMS_REGION.toString()))
-          .build();
+                .builder()
+                .credentialsProvider(creds)
+                .region(Region.of(KMS_REGION.toString()))
+                .build();
         KmsClient kmsClient = KmsClient
-          .builder()
-          .credentialsProvider(creds)
-          .region(Region.of(KMS_REGION.toString()))
-          .build();
+                .builder()
+                .credentialsProvider(creds)
+                .region(Region.of(KMS_REGION.toString()))
+                .build();
 
         KmsKeyring keyring = KmsKeyring
-          .builder()
-          .kmsClient(kmsClient)
-          .wrappingKeyId(KMS_KEY_ID)
-          .build();
+                .builder()
+                .kmsClient(kmsClient)
+                .wrappingKeyId(KMS_KEY_ID)
+                .build();
         S3AsyncClient s3Client = S3AsyncEncryptionClient.builder()
-          .wrappedClient(wrappedAsyncClient)
-          .keyring(keyring)
-          .build();
+                .wrappedClient(wrappedAsyncClient)
+                .keyring(keyring)
+                .build();
 
         final String input = "SimpleTestOfV3EncryptionClientAsync";
 
         s3Client.putObject(builder -> builder
-            .bucket(BUCKET)
-            .key(objectKey)
-            .build(),
-          AsyncRequestBody.fromString(input)).join();
+                        .bucket(BUCKET)
+                        .key(objectKey)
+                        .build(),
+                AsyncRequestBody.fromString(input)).join();
 
         ResponseBytes<GetObjectResponse> objectResponse = s3Client.getObject(builder -> builder
-          .bucket(BUCKET)
-          .key(objectKey)
-          .build(), AsyncResponseTransformer.toBytes()).join();
+                .bucket(BUCKET)
+                .key(objectKey)
+                .build(), AsyncResponseTransformer.toBytes()).join();
         String output = objectResponse.asUtf8String();
         assertEquals(input, output);
 
@@ -136,23 +136,23 @@ public class S3AsyncEncryptionClientTest {
         AwsCredentialsProvider creds = DefaultCredentialsProvider.create();
 
         S3AsyncClient s3Client = S3AsyncEncryptionClient.builder()
-          .credentialsProvider(creds)
-          .region(Region.of(KMS_REGION.toString()))
-          .kmsKeyId(KMS_KEY_ID)
-          .build();
+                .credentialsProvider(creds)
+                .region(Region.of(KMS_REGION.toString()))
+                .kmsKeyId(KMS_KEY_ID)
+                .build();
 
         final String input = "SimpleTestOfV3EncryptionClientAsync";
 
         s3Client.putObject(builder -> builder
-            .bucket(BUCKET)
-            .key(objectKey)
-            .build(),
-          AsyncRequestBody.fromString(input)).join();
+                        .bucket(BUCKET)
+                        .key(objectKey)
+                        .build(),
+                AsyncRequestBody.fromString(input)).join();
 
         ResponseBytes<GetObjectResponse> objectResponse = s3Client.getObject(builder -> builder
-          .bucket(BUCKET)
-          .key(objectKey)
-          .build(), AsyncResponseTransformer.toBytes()).join();
+                .bucket(BUCKET)
+                .key(objectKey)
+                .build(), AsyncResponseTransformer.toBytes()).join();
         String output = objectResponse.asUtf8String();
         assertEquals(input, output);
 
@@ -170,18 +170,18 @@ public class S3AsyncEncryptionClientTest {
         AwsCredentialsProvider creds = new S3EncryptionClientTestResources.AlternateRoleCredentialsProvider();
 
         S3AsyncClient s3Client = S3AsyncEncryptionClient.builder()
-          .credentialsProvider(creds)
-          .region(Region.of(KMS_REGION.toString()))
-          .kmsKeyId(KMS_KEY_ID)
-          .build();
+                .credentialsProvider(creds)
+                .region(Region.of(KMS_REGION.toString()))
+                .kmsKeyId(KMS_KEY_ID)
+                .build();
 
         // using the original key fails
         try {
             s3Client.putObject(builder -> builder
-                .bucket(BUCKET)
-                .key(objectKey)
-                .build(),
-              AsyncRequestBody.fromString(input)).join();
+                            .bucket(BUCKET)
+                            .key(objectKey)
+                            .build(),
+                    AsyncRequestBody.fromString(input)).join();
             fail("expected exception");
         } catch (KmsException exception) {
             // expected
@@ -192,21 +192,21 @@ public class S3AsyncEncryptionClientTest {
 
         // using the alternate key succeeds
         S3AsyncClient s3ClientAltCreds = S3AsyncEncryptionClient.builder()
-          .credentialsProvider(creds)
-          .region(Region.of(KMS_REGION.toString()))
-          .kmsKeyId(ALTERNATE_KMS_KEY)
-          .build();
+                .credentialsProvider(creds)
+                .region(Region.of(KMS_REGION.toString()))
+                .kmsKeyId(ALTERNATE_KMS_KEY)
+                .build();
 
         s3ClientAltCreds.putObject(builder -> builder
-            .bucket(BUCKET)
-            .key(objectKey)
-            .build(),
-          AsyncRequestBody.fromString(input)).join();
+                        .bucket(BUCKET)
+                        .key(objectKey)
+                        .build(),
+                AsyncRequestBody.fromString(input)).join();
 
         ResponseBytes<GetObjectResponse> objectResponse = s3ClientAltCreds.getObject(builder -> builder
-          .bucket(BUCKET)
-          .key(objectKey)
-          .build(), AsyncResponseTransformer.toBytes()).join();
+                .bucket(BUCKET)
+                .key(objectKey)
+                .build(), AsyncResponseTransformer.toBytes()).join();
         String output = objectResponse.asUtf8String();
         assertEquals(input, output);
 
@@ -224,30 +224,30 @@ public class S3AsyncEncryptionClientTest {
         // default for S3
         AwsCredentialsProvider creds = new S3EncryptionClientTestResources.AlternateRoleCredentialsProvider();
         KmsClient kmsClient = KmsClient.builder()
-          .credentialsProvider(creds)
-          .region(Region.of(KMS_REGION.toString()))
-          .build();
+                .credentialsProvider(creds)
+                .region(Region.of(KMS_REGION.toString()))
+                .build();
         KmsKeyring kmsKeyring = KmsKeyring.builder()
-          .kmsClient(kmsClient)
-          .wrappingKeyId(ALTERNATE_KMS_KEY)
-          .build();
+                .kmsClient(kmsClient)
+                .wrappingKeyId(ALTERNATE_KMS_KEY)
+                .build();
 
         S3AsyncClient s3Client = S3AsyncEncryptionClient.builder()
-          .credentialsProvider(creds)
-          .region(Region.of(KMS_REGION.toString()))
-          .keyring(kmsKeyring)
-          .build();
+                .credentialsProvider(creds)
+                .region(Region.of(KMS_REGION.toString()))
+                .keyring(kmsKeyring)
+                .build();
 
         s3Client.putObject(builder -> builder
-            .bucket(BUCKET)
-            .key(objectKey)
-            .build(),
-          AsyncRequestBody.fromString(input)).join();
+                        .bucket(BUCKET)
+                        .key(objectKey)
+                        .build(),
+                AsyncRequestBody.fromString(input)).join();
 
         ResponseBytes<GetObjectResponse> objectResponse = s3Client.getObject(builder -> builder
-          .bucket(BUCKET)
-          .key(objectKey)
-          .build(), AsyncResponseTransformer.toBytes()).join();
+                .bucket(BUCKET)
+                .key(objectKey)
+                .build(), AsyncResponseTransformer.toBytes()).join();
         String output = objectResponse.asUtf8String();
         assertEquals(input, output);
 
@@ -264,19 +264,19 @@ public class S3AsyncEncryptionClientTest {
         AwsCredentialsProvider creds = DefaultCredentialsProvider.create();
 
         S3AsyncClient s3Client = S3AsyncEncryptionClient.builder()
-          .credentialsProvider(creds)
-          .region(Region.of("eu-west-1"))
-          .kmsKeyId(KMS_KEY_ID)
-          .build();
+                .credentialsProvider(creds)
+                .region(Region.of("eu-west-1"))
+                .kmsKeyId(KMS_KEY_ID)
+                .build();
 
         final String input = "SimpleTestOfV3EncryptionClientAsync";
 
         try {
             s3Client.putObject(builder -> builder
-                .bucket(BUCKET)
-                .key(objectKey)
-                .build(),
-              AsyncRequestBody.fromString(input)).join();
+                            .bucket(BUCKET)
+                            .key(objectKey)
+                            .build(),
+                    AsyncRequestBody.fromString(input)).join();
             fail("expected exception");
         } catch (NotFoundException e) {
             assertTrue(e.getMessage().contains("Invalid arn"));
@@ -292,19 +292,19 @@ public class S3AsyncEncryptionClientTest {
         AwsCredentialsProvider creds = new S3EncryptionClientTestResources.NullCredentialsProvider();
 
         S3AsyncClient s3Client = S3AsyncEncryptionClient.builder()
-          .credentialsProvider(creds)
-          .region(Region.of(KMS_REGION.toString()))
-          .kmsKeyId(KMS_KEY_ID)
-          .build();
+                .credentialsProvider(creds)
+                .region(Region.of(KMS_REGION.toString()))
+                .kmsKeyId(KMS_KEY_ID)
+                .build();
 
         final String input = "SimpleTestOfV3EncryptionClientAsync";
 
         try {
             s3Client.putObject(builder -> builder
-                .bucket(BUCKET)
-                .key(objectKey)
-                .build(),
-              AsyncRequestBody.fromString(input)).join();
+                            .bucket(BUCKET)
+                            .key(objectKey)
+                            .build(),
+                    AsyncRequestBody.fromString(input)).join();
             fail("expected exception");
         } catch (NullPointerException npe) {
             assertTrue(npe.getMessage().contains("Access key ID cannot be blank"));

--- a/src/test/java/software/amazon/encryption/s3/S3AsyncEncryptionClientTest.java
+++ b/src/test/java/software/amazon/encryption/s3/S3AsyncEncryptionClientTest.java
@@ -113,7 +113,7 @@ public class S3AsyncEncryptionClientTest {
             .bucket(BUCKET)
             .key(objectKey)
             .build(),
-          AsyncRequestBody.fromString(input));
+          AsyncRequestBody.fromString(input)).join();
 
         ResponseBytes<GetObjectResponse> objectResponse = s3Client.getObject(builder -> builder
           .bucket(BUCKET)
@@ -147,7 +147,7 @@ public class S3AsyncEncryptionClientTest {
             .bucket(BUCKET)
             .key(objectKey)
             .build(),
-          AsyncRequestBody.fromString(input));
+          AsyncRequestBody.fromString(input)).join();
 
         ResponseBytes<GetObjectResponse> objectResponse = s3Client.getObject(builder -> builder
           .bucket(BUCKET)
@@ -181,7 +181,7 @@ public class S3AsyncEncryptionClientTest {
                 .bucket(BUCKET)
                 .key(objectKey)
                 .build(),
-              AsyncRequestBody.fromString(input));
+              AsyncRequestBody.fromString(input)).join();
             fail("expected exception");
         } catch (S3EncryptionClientException exception) {
             // expected
@@ -202,7 +202,7 @@ public class S3AsyncEncryptionClientTest {
             .bucket(BUCKET)
             .key(objectKey)
             .build(),
-          AsyncRequestBody.fromString(input));
+          AsyncRequestBody.fromString(input)).join();
 
         ResponseBytes<GetObjectResponse> objectResponse = s3Client.getObject(builder -> builder
           .bucket(BUCKET)
@@ -217,7 +217,7 @@ public class S3AsyncEncryptionClientTest {
     }
 
     @Test
-    public void s3EncryptionClientMixedCredentials() {
+    public void s3AsyncEncryptionClientMixedCredentials() {
         final String objectKey = appendTestSuffix("wrapped-s3-client-with-mixed-credentials");
         final String input = "S3EncryptionClientTopLevelAlternateCredsTest";
 
@@ -236,14 +236,14 @@ public class S3AsyncEncryptionClientTest {
         S3AsyncClient s3Client = S3AsyncEncryptionClient.builder()
           .credentialsProvider(creds)
           .region(Region.of(KMS_REGION.toString()))
-          .kmsKeyId(ALTERNATE_KMS_KEY)
+          .keyring(kmsKeyring)
           .build();
 
         s3Client.putObject(builder -> builder
             .bucket(BUCKET)
             .key(objectKey)
             .build(),
-          AsyncRequestBody.fromString(input));
+          AsyncRequestBody.fromString(input)).join();
 
         ResponseBytes<GetObjectResponse> objectResponse = s3Client.getObject(builder -> builder
           .bucket(BUCKET)
@@ -257,6 +257,7 @@ public class S3AsyncEncryptionClientTest {
         s3Client.close();
         kmsClient.close();
     }
+
     @Test
     public void putAsyncGetDefault() {
         final String objectKey = appendTestSuffix("put-async-get-default");

--- a/src/test/java/software/amazon/encryption/s3/S3EncryptionClientCompatibilityTest.java
+++ b/src/test/java/software/amazon/encryption/s3/S3EncryptionClientCompatibilityTest.java
@@ -2,8 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 package software.amazon.encryption.s3;
 
-import com.amazonaws.regions.Region;
-import com.amazonaws.regions.Regions;
 import com.amazonaws.services.kms.AWSKMS;
 import com.amazonaws.services.kms.AWSKMSClientBuilder;
 import com.amazonaws.services.s3.AmazonS3Encryption;
@@ -43,6 +41,9 @@ import java.util.Map;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static software.amazon.encryption.s3.S3EncryptionClient.withAdditionalConfiguration;
+import static software.amazon.encryption.s3.utils.S3EncryptionClientTestResources.BUCKET;
+import static software.amazon.encryption.s3.utils.S3EncryptionClientTestResources.KMS_KEY_ID;
+import static software.amazon.encryption.s3.utils.S3EncryptionClientTestResources.KMS_REGION;
 import static software.amazon.encryption.s3.utils.S3EncryptionClientTestResources.appendTestSuffix;
 import static software.amazon.encryption.s3.utils.S3EncryptionClientTestResources.deleteObject;
 
@@ -51,10 +52,6 @@ import static software.amazon.encryption.s3.utils.S3EncryptionClientTestResource
  * between V1, V2, and V3 clients under various conditions.
  */
 public class S3EncryptionClientCompatibilityTest {
-
-    private static final String BUCKET = System.getenv("AWS_S3EC_TEST_BUCKET");
-    private static final String KMS_KEY_ID = System.getenv("AWS_S3EC_TEST_KMS_KEY_ID");
-    private static final Region KMS_REGION = Region.getRegion(Regions.fromName(System.getenv("AWS_REGION")));
 
     private static SecretKey AES_KEY;
     private static KeyPair RSA_KEY_PAIR;

--- a/src/test/java/software/amazon/encryption/s3/S3EncryptionClientRangedGetCompatibilityTest.java
+++ b/src/test/java/software/amazon/encryption/s3/S3EncryptionClientRangedGetCompatibilityTest.java
@@ -2,8 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 package software.amazon.encryption.s3;
 
-import com.amazonaws.regions.Region;
-import com.amazonaws.regions.Regions;
 import com.amazonaws.services.kms.AWSKMS;
 import com.amazonaws.services.kms.AWSKMSClientBuilder;
 import com.amazonaws.services.s3.AmazonS3Encryption;
@@ -38,6 +36,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static software.amazon.encryption.s3.utils.S3EncryptionClientTestResources.BUCKET;
 import static software.amazon.encryption.s3.utils.S3EncryptionClientTestResources.KMS_KEY_ID;
+import static software.amazon.encryption.s3.utils.S3EncryptionClientTestResources.KMS_REGION;
 import static software.amazon.encryption.s3.utils.S3EncryptionClientTestResources.appendTestSuffix;
 import static software.amazon.encryption.s3.utils.S3EncryptionClientTestResources.deleteObject;
 
@@ -46,7 +45,6 @@ import static software.amazon.encryption.s3.utils.S3EncryptionClientTestResource
  */
 public class S3EncryptionClientRangedGetCompatibilityTest {
 
-    private static final Region KMS_REGION = Region.getRegion(Regions.fromName(System.getenv("AWS_REGION")));
     private static SecretKey AES_KEY;
     private static KeyPair RSA_KEY_PAIR;
 

--- a/src/test/java/software/amazon/encryption/s3/S3EncryptionClientTest.java
+++ b/src/test/java/software/amazon/encryption/s3/S3EncryptionClientTest.java
@@ -736,29 +736,6 @@ public class S3EncryptionClientTest {
         s3Client.close();
     }
 
-    /**
-     * A simple, reusable round-trip (encryption + decryption) using a given
-     * S3Client. Useful for testing client configuration.
-     *
-     * @param v3Client the client under test
-     */
-    private void simpleV3RoundTrip(final S3Client v3Client, final String objectKey) {
-        final String input = "SimpleTestOfV3EncryptionClient";
-
-        v3Client.putObject(builder -> builder
-                        .bucket(BUCKET)
-                        .key(objectKey)
-                        .build(),
-                RequestBody.fromString(input));
-
-        ResponseBytes<GetObjectResponse> objectResponse = v3Client.getObjectAsBytes(builder -> builder
-                .bucket(BUCKET)
-                .key(objectKey)
-                .build());
-        String output = objectResponse.asUtf8String();
-        assertEquals(input, output);
-    }
-
     @Test
     public void s3EncryptionClientTopLevelCredentials() {
         final String objectKey = appendTestSuffix("wrapped-s3-client-with-top-level-credentials");
@@ -812,7 +789,7 @@ public class S3EncryptionClientTest {
 
         S3Client s3Client = S3EncryptionClient.builder()
           .credentialsProvider(creds)
-          .region(Region.of("eu-west-1"))
+          .region(Region.of(KMS_REGION.toString()))
           .kmsKeyId(KMS_KEY_ID)
           .build();
 
@@ -893,5 +870,28 @@ public class S3EncryptionClientTest {
         deleteObject(BUCKET, objectKey, s3Client);
         s3Client.close();
         kmsClient.close();
+    }
+
+    /**
+     * A simple, reusable round-trip (encryption + decryption) using a given
+     * S3Client. Useful for testing client configuration.
+     *
+     * @param v3Client the client under test
+     */
+    private void simpleV3RoundTrip(final S3Client v3Client, final String objectKey) {
+        final String input = "SimpleTestOfV3EncryptionClient";
+
+        v3Client.putObject(builder -> builder
+            .bucket(BUCKET)
+            .key(objectKey)
+            .build(),
+          RequestBody.fromString(input));
+
+        ResponseBytes<GetObjectResponse> objectResponse = v3Client.getObjectAsBytes(builder -> builder
+          .bucket(BUCKET)
+          .key(objectKey)
+          .build());
+        String output = objectResponse.asUtf8String();
+        assertEquals(input, output);
     }
 }

--- a/src/test/java/software/amazon/encryption/s3/S3EncryptionClientTest.java
+++ b/src/test/java/software/amazon/encryption/s3/S3EncryptionClientTest.java
@@ -399,8 +399,8 @@ public class S3EncryptionClientTest {
         KmsKeyring keyring = KmsKeyring.builder().wrappingKeyId(KMS_KEY_ID).build();
 
         S3Client v3Client = S3EncryptionClient.builder()
-            .keyring(keyring)
-            .build();
+                .keyring(keyring)
+                .build();
 
         simpleV3RoundTrip(v3Client, objectKey);
 
@@ -416,12 +416,12 @@ public class S3EncryptionClientTest {
         KmsKeyring keyring = KmsKeyring.builder().wrappingKeyId(KMS_KEY_ID).build();
 
         CryptographicMaterialsManager cmm = DefaultCryptoMaterialsManager.builder()
-            .keyring(keyring)
-            .build();
+                .keyring(keyring)
+                .build();
 
         S3Client v3Client = S3EncryptionClient.builder()
-            .cryptoMaterialsManager(cmm)
-            .build();
+                .cryptoMaterialsManager(cmm)
+                .build();
 
         simpleV3RoundTrip(v3Client, objectKey);
 
@@ -459,21 +459,21 @@ public class S3EncryptionClientTest {
     @Test
     public void s3EncryptionClientWithWrappedS3EncryptionClientFails() {
         S3AsyncClient wrappedAsyncClient = S3AsyncEncryptionClient.builder()
-            .kmsKeyId(KMS_KEY_ID)
-            .build();
+                .kmsKeyId(KMS_KEY_ID)
+                .build();
 
         assertThrows(S3EncryptionClientException.class, () -> S3EncryptionClient.builder()
-            .wrappedAsyncClient(wrappedAsyncClient)
-            .kmsKeyId(KMS_KEY_ID)
-            .build());
+                .wrappedAsyncClient(wrappedAsyncClient)
+                .kmsKeyId(KMS_KEY_ID)
+                .build());
     }
 
     @Test
     public void s3EncryptionClientWithNullSecureRandomFails() {
         assertThrows(S3EncryptionClientException.class, () -> S3EncryptionClient.builder()
-            .aesKey(AES_KEY)
-            .secureRandom(null)
-            .build());
+                .aesKey(AES_KEY)
+                .secureRandom(null)
+                .build());
     }
 
     @Test
@@ -483,8 +483,8 @@ public class S3EncryptionClientTest {
         final String objectKey = appendTestSuffix("no-secure-random-object-kms");
 
         S3Client v3Client = S3EncryptionClient.builder()
-            .kmsKeyId(KMS_KEY_ID)
-            .build();
+                .kmsKeyId(KMS_KEY_ID)
+                .build();
 
         simpleV3RoundTrip(v3Client, objectKey);
 
@@ -704,28 +704,28 @@ public class S3EncryptionClientTest {
         AwsCredentialsProvider creds = DefaultCredentialsProvider.create();
 
         S3Client wrappedClient = S3Client
-          .builder()
-          .credentialsProvider(creds)
-          .build();
+                .builder()
+                .credentialsProvider(creds)
+                .build();
         S3AsyncClient wrappedAsyncClient = S3AsyncClient
-          .builder()
-          .credentialsProvider(creds)
-          .build();
+                .builder()
+                .credentialsProvider(creds)
+                .build();
         KmsClient kmsClient = KmsClient
-          .builder()
-          .credentialsProvider(creds)
-          .build();
+                .builder()
+                .credentialsProvider(creds)
+                .build();
 
         KmsKeyring keyring = KmsKeyring
-          .builder()
-          .kmsClient(kmsClient)
-          .wrappingKeyId(KMS_KEY_ID)
-          .build();
+                .builder()
+                .kmsClient(kmsClient)
+                .wrappingKeyId(KMS_KEY_ID)
+                .build();
         S3Client s3Client = S3EncryptionClient.builder()
-          .wrappedClient(wrappedClient)
-          .wrappedAsyncClient(wrappedAsyncClient)
-          .keyring(keyring)
-          .build();
+                .wrappedClient(wrappedClient)
+                .wrappedAsyncClient(wrappedAsyncClient)
+                .keyring(keyring)
+                .build();
 
         simpleV3RoundTrip(s3Client, objectKey);
 
@@ -744,10 +744,10 @@ public class S3EncryptionClientTest {
         AwsCredentialsProvider creds = DefaultCredentialsProvider.create();
 
         S3Client s3Client = S3EncryptionClient.builder()
-          .credentialsProvider(creds)
-          .region(Region.of(KMS_REGION.toString()))
-          .kmsKeyId(KMS_KEY_ID)
-          .build();
+                .credentialsProvider(creds)
+                .region(Region.of(KMS_REGION.toString()))
+                .kmsKeyId(KMS_KEY_ID)
+                .build();
 
         simpleV3RoundTrip(s3Client, objectKey);
 
@@ -764,10 +764,10 @@ public class S3EncryptionClientTest {
         AwsCredentialsProvider creds = DefaultCredentialsProvider.create();
 
         S3Client s3Client = S3EncryptionClient.builder()
-          .credentialsProvider(creds)
-          .region(Region.of("eu-west-1"))
-          .kmsKeyId(KMS_KEY_ID)
-          .build();
+                .credentialsProvider(creds)
+                .region(Region.of("eu-west-1"))
+                .kmsKeyId(KMS_KEY_ID)
+                .build();
 
         try {
             simpleV3RoundTrip(s3Client, objectKey);
@@ -788,10 +788,10 @@ public class S3EncryptionClientTest {
         AwsCredentialsProvider creds = new S3EncryptionClientTestResources.NullCredentialsProvider();
 
         S3Client s3Client = S3EncryptionClient.builder()
-          .credentialsProvider(creds)
-          .region(Region.of(KMS_REGION.toString()))
-          .kmsKeyId(KMS_KEY_ID)
-          .build();
+                .credentialsProvider(creds)
+                .region(Region.of(KMS_REGION.toString()))
+                .kmsKeyId(KMS_KEY_ID)
+                .build();
 
         try {
             simpleV3RoundTrip(s3Client, objectKey);
@@ -813,10 +813,10 @@ public class S3EncryptionClientTest {
         AwsCredentialsProvider creds = new S3EncryptionClientTestResources.AlternateRoleCredentialsProvider();
 
         S3Client s3Client = S3EncryptionClient.builder()
-          .credentialsProvider(creds)
-          .region(Region.of(KMS_REGION.toString()))
-          .kmsKeyId(KMS_KEY_ID)
-          .build();
+                .credentialsProvider(creds)
+                .region(Region.of(KMS_REGION.toString()))
+                .kmsKeyId(KMS_KEY_ID)
+                .build();
 
         // using the original key fails
         try {
@@ -832,10 +832,10 @@ public class S3EncryptionClientTest {
 
         // using the alternate key succeeds
         S3Client s3ClientAltCreds = S3EncryptionClient.builder()
-          .credentialsProvider(creds)
-          .region(Region.of(KMS_REGION.toString()))
-          .kmsKeyId(ALTERNATE_KMS_KEY)
-          .build();
+                .credentialsProvider(creds)
+                .region(Region.of(KMS_REGION.toString()))
+                .kmsKeyId(ALTERNATE_KMS_KEY)
+                .build();
 
         simpleV3RoundTrip(s3ClientAltCreds, objectKey);
 
@@ -852,17 +852,17 @@ public class S3EncryptionClientTest {
         // default for S3
         AwsCredentialsProvider creds = new S3EncryptionClientTestResources.AlternateRoleCredentialsProvider();
         KmsClient kmsClient = KmsClient.builder()
-          .credentialsProvider(creds)
-          .region(Region.of(KMS_REGION.toString()))
-          .build();
+                .credentialsProvider(creds)
+                .region(Region.of(KMS_REGION.toString()))
+                .build();
         KmsKeyring kmsKeyring = KmsKeyring.builder()
-          .kmsClient(kmsClient)
-          .wrappingKeyId(ALTERNATE_KMS_KEY)
-          .build();
+                .kmsClient(kmsClient)
+                .wrappingKeyId(ALTERNATE_KMS_KEY)
+                .build();
 
         S3Client s3Client = S3EncryptionClient.builder()
-          .keyring(kmsKeyring)
-          .build();
+                .keyring(kmsKeyring)
+                .build();
 
         simpleV3RoundTrip(s3Client, objectKey);
 
@@ -882,15 +882,15 @@ public class S3EncryptionClientTest {
         final String input = "SimpleTestOfV3EncryptionClient";
 
         v3Client.putObject(builder -> builder
-            .bucket(BUCKET)
-            .key(objectKey)
-            .build(),
-          RequestBody.fromString(input));
+                        .bucket(BUCKET)
+                        .key(objectKey)
+                        .build(),
+                RequestBody.fromString(input));
 
         ResponseBytes<GetObjectResponse> objectResponse = v3Client.getObjectAsBytes(builder -> builder
-          .bucket(BUCKET)
-          .key(objectKey)
-          .build());
+                .bucket(BUCKET)
+                .key(objectKey)
+                .build());
         String output = objectResponse.asUtf8String();
         assertEquals(input, output);
     }

--- a/src/test/java/software/amazon/encryption/s3/examples/ClientConfigurationExampleTest.java
+++ b/src/test/java/software/amazon/encryption/s3/examples/ClientConfigurationExampleTest.java
@@ -1,0 +1,10 @@
+package software.amazon.encryption.s3.examples;
+
+import org.junit.jupiter.api.Test;
+
+public class ClientConfigurationExampleTest {
+  @Test
+  public void testClientConfigurationExamples() {
+    ClientConfigurationExample.main(new String[0]);
+  }
+}

--- a/src/test/java/software/amazon/encryption/s3/examples/ClientConfigurationExampleTest.java
+++ b/src/test/java/software/amazon/encryption/s3/examples/ClientConfigurationExampleTest.java
@@ -5,6 +5,6 @@ import org.junit.jupiter.api.Test;
 public class ClientConfigurationExampleTest {
   @Test
   public void testClientConfigurationExamples() {
-    ClientConfigurationExample.main(new String[0]);
+      ClientConfigurationExample.main(new String[0]);
   }
 }

--- a/src/test/java/software/amazon/encryption/s3/utils/S3EncryptionClientTestResources.java
+++ b/src/test/java/software/amazon/encryption/s3/utils/S3EncryptionClientTestResources.java
@@ -53,10 +53,10 @@ public class S3EncryptionClientTestResources {
         public AwsCredentials resolveCredentials() {
             String sessionName = "s3ec-test" + DateTimeFormat.forPattern("-yyMMdd-hhmmss").print(new DateTime());
             Credentials assumeRoleCreds = stsClient_.assumeRole(builder -> builder
-              .roleArn(ALTERNATE_ROLE_ARN).roleSessionName(sessionName).build()).credentials();
+                    .roleArn(ALTERNATE_ROLE_ARN).roleSessionName(sessionName).build()).credentials();
             return AwsSessionCredentials.create(assumeRoleCreds.accessKeyId(),
-              assumeRoleCreds.secretAccessKey(),
-              assumeRoleCreds.sessionToken());
+                    assumeRoleCreds.secretAccessKey(),
+                    assumeRoleCreds.sessionToken());
         }
     }
 
@@ -69,7 +69,7 @@ public class S3EncryptionClientTestResources {
         @Override
         public AwsCredentials resolveCredentials() {
             return AwsBasicCredentials
-              .create(null, null);
+                    .create(null, null);
         }
     }
 

--- a/src/test/java/software/amazon/encryption/s3/utils/S3EncryptionClientTestResources.java
+++ b/src/test/java/software/amazon/encryption/s3/utils/S3EncryptionClientTestResources.java
@@ -2,8 +2,13 @@
 // SPDX-License-Identifier: Apache-2.0
 package software.amazon.encryption.s3.utils;
 
+import com.amazonaws.regions.Region;
+import com.amazonaws.regions.Regions;
 import org.joda.time.DateTime;
 import org.joda.time.format.DateTimeFormat;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.AwsCredentials;
+import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
 import software.amazon.awssdk.services.s3.S3AsyncClient;
 import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.model.DeleteObjectResponse;
@@ -19,6 +24,20 @@ public class S3EncryptionClientTestResources {
     public static final String KMS_KEY_ID = System.getenv("AWS_S3EC_TEST_KMS_KEY_ID");
     // This alias must point to the same key as KMS_KEY_ID
     public static final String KMS_KEY_ALIAS = System.getenv("AWS_S3EC_TEST_KMS_KEY_ALIAS");
+    public static final Region KMS_REGION = Region.getRegion(Regions.fromName(System.getenv("AWS_REGION")));
+
+    public static class NullCredentialsProvider implements AwsCredentialsProvider {
+
+        public NullCredentialsProvider() {
+            super();
+        }
+
+        @Override
+        public AwsCredentials resolveCredentials() {
+            return AwsBasicCredentials
+              .create(null, null);
+        }
+    }
 
     /**
      * For a given string, append a suffix to distinguish it from

--- a/src/test/java/software/amazon/encryption/s3/utils/S3EncryptionClientTestResources.java
+++ b/src/test/java/software/amazon/encryption/s3/utils/S3EncryptionClientTestResources.java
@@ -27,6 +27,8 @@ public class S3EncryptionClientTestResources {
     public static final String KMS_KEY_ID = System.getenv("AWS_S3EC_TEST_KMS_KEY_ID");
     // This alias must point to the same key as KMS_KEY_ID
     public static final String KMS_KEY_ALIAS = System.getenv("AWS_S3EC_TEST_KMS_KEY_ALIAS");
+    // For now, these are the same.
+    public static final Region S3_REGION = Region.getRegion(Regions.fromName(System.getenv("AWS_REGION")));
     public static final Region KMS_REGION = Region.getRegion(Regions.fromName(System.getenv("AWS_REGION")));
     // Alternate role to test credential configuration and access denied behavior
     public static final String ALTERNATE_ROLE_ARN = System.getenv("AWS_S3EC_TEST_ALT_ROLE_ARN");


### PR DESCRIPTION
*Issue #, if available:* https://github.com/aws/amazon-s3-encryption-client-java/issues/226

*Description of changes:* Adds "top-level" client configuration options to the S3 Encryption Client. This lets customers set configuration, e.g. credentials or region in one place which is then propagated to each of the "inner" clients used by the S3EC. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

# Check any applicable:
- [ ] Were any files moved? Moving files changes their URL, which breaks all hyperlinks to the files.
