### PR TITLE
chore: fix release javadocs

### DIFF
--- a/codebuild/release/javadoc.yml
+++ b/codebuild/release/javadoc.yml
@@ -18,7 +18,7 @@ phases:
   build:
     commands:
       - mvn javadoc:javadoc
-      - cp -r ./target/site/apidocs /tmp
+      - cp -r ./target/reports/apidocs /tmp
       - git checkout $GH_PAGES
       - cp -r /tmp/apidocs/* .
       - git add .


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

This step failed during the latest release. I ran it locally and it seems the path which javadocs are built to has changed. 


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

# Check any applicable:
- [ ] Were any files moved? Moving files changes their URL, which breaks all hyperlinks to the files.
