### PR TITLE
fix: introduce S3-specific client configuration to top-level configuration

### DIFF
--- a/src/main/java/software/amazon/encryption/s3/S3AsyncEncryptionClient.java
+++ b/src/main/java/software/amazon/encryption/s3/S3AsyncEncryptionClient.java
@@ -5,7 +5,6 @@ package software.amazon.encryption.s3;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
 import software.amazon.awssdk.awscore.AwsRequestOverrideConfiguration;
-import software.amazon.awssdk.awscore.client.builder.AwsAsyncClientBuilder;
 import software.amazon.awssdk.awscore.exception.AwsServiceException;
 import software.amazon.awssdk.core.async.AsyncRequestBody;
 import software.amazon.awssdk.core.async.AsyncResponseTransformer;
@@ -18,6 +17,8 @@ import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.kms.KmsClient;
 import software.amazon.awssdk.services.s3.DelegatingS3AsyncClient;
 import software.amazon.awssdk.services.s3.S3AsyncClient;
+import software.amazon.awssdk.services.s3.S3AsyncClientBuilder;
+import software.amazon.awssdk.services.s3.S3Configuration;
 import software.amazon.awssdk.services.s3.internal.crt.S3CrtAsyncClient;
 import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
 import software.amazon.awssdk.services.s3.model.DeleteObjectResponse;
@@ -259,7 +260,7 @@ public class S3AsyncEncryptionClient extends DelegatingS3AsyncClient {
 
     // This is very similar to the S3EncryptionClient builder
     // Make sure to keep both clients in mind when adding new builder options
-    public static class Builder implements AwsAsyncClientBuilder<Builder, S3AsyncEncryptionClient> {
+    public static class Builder implements S3AsyncClientBuilder {
         private S3AsyncClient _wrappedClient;
         private CryptographicMaterialsManager _cryptoMaterialsManager;
         private Keyring _keyring;
@@ -286,6 +287,11 @@ public class S3AsyncEncryptionClient extends DelegatingS3AsyncClient {
         private ClientAsyncConfiguration _clientAsyncConfiguration = null;
         private SdkAsyncHttpClient _sdkAsyncHttpClient = null;
         private SdkAsyncHttpClient.Builder _sdkAsyncHttpClientBuilder = null;
+        private S3Configuration _serviceConfiguration = null;
+        private Boolean _accelerate = null;
+        private Boolean _disableMultiRegionAccessPoints = null;
+        private Boolean _forcePathStyle = null;
+        private Boolean _useArnRegion = null;
 
         private Builder() {
         }
@@ -661,6 +667,57 @@ public class S3AsyncEncryptionClient extends DelegatingS3AsyncClient {
             return this;
         }
 
+        @Override
+        public S3AsyncClientBuilder serviceConfiguration(S3Configuration serviceConfiguration) {
+            _serviceConfiguration = serviceConfiguration;
+            return this;
+        }
+
+        /**
+         * Enables this client to use S3 Transfer Acceleration endpoints.
+         *
+         * @param accelerate
+         */
+        @Override
+        public S3AsyncClientBuilder accelerate(Boolean accelerate) {
+            _accelerate = accelerate;
+            return this;
+        }
+
+        /**
+         * Disables this client's usage of Multi-Region Access Points.
+         *
+         * @param disableMultiRegionAccessPoints
+         */
+        @Override
+        public S3AsyncClientBuilder disableMultiRegionAccessPoints(Boolean disableMultiRegionAccessPoints) {
+            _disableMultiRegionAccessPoints = disableMultiRegionAccessPoints;
+            return this;
+        }
+
+        /**
+         * Forces this client to use path-style addressing for buckets.
+         *
+         * @param forcePathStyle
+         */
+        @Override
+        public S3AsyncClientBuilder forcePathStyle(Boolean forcePathStyle) {
+            _forcePathStyle = forcePathStyle;
+            return this;
+        }
+
+        /**
+         * Enables this client to use an ARN's region when constructing an endpoint instead of the client's configured
+         * region.
+         *
+         * @param useArnRegion
+         */
+        @Override
+        public S3AsyncClientBuilder useArnRegion(Boolean useArnRegion) {
+            _useArnRegion = useArnRegion;
+            return this;
+        }
+
         /**
          * Validates and builds the S3AsyncEncryptionClient according
          * to the configuration options passed to the Builder object.
@@ -690,6 +747,11 @@ public class S3AsyncEncryptionClient extends DelegatingS3AsyncClient {
                         .asyncConfiguration(_clientAsyncConfiguration != null ? _clientAsyncConfiguration : ClientAsyncConfiguration.builder().build())
                         .httpClient(_sdkAsyncHttpClient)
                         .httpClientBuilder(_sdkAsyncHttpClientBuilder)
+                        .serviceConfiguration(_serviceConfiguration)
+                        .accelerate(_accelerate)
+                        .disableMultiRegionAccessPoints(_disableMultiRegionAccessPoints)
+                        .forcePathStyle(_forcePathStyle)
+                        .useArnRegion(_useArnRegion)
                         .build();
             }
 
@@ -733,5 +795,6 @@ public class S3AsyncEncryptionClient extends DelegatingS3AsyncClient {
 
             return new S3AsyncEncryptionClient(this);
         }
+
     }
 }

--- a/src/main/java/software/amazon/encryption/s3/S3AsyncEncryptionClient.java
+++ b/src/main/java/software/amazon/encryption/s3/S3AsyncEncryptionClient.java
@@ -48,6 +48,7 @@ import java.security.Provider;
 import java.security.SecureRandom;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Consumer;
 import java.util.function.Function;
@@ -554,7 +555,7 @@ public class S3AsyncEncryptionClient extends DelegatingS3AsyncClient {
          * <p>If the setting is not found in any of the locations above, 'false' will be used.
          */
         public Builder dualstackEnabled(Boolean isDualStackEnabled) {
-            _dualStackEnabled = isDualStackEnabled;
+            _dualStackEnabled = Optional.ofNullable(isDualStackEnabled).orElse(Boolean.FALSE);
             return this;
         }
 
@@ -575,7 +576,7 @@ public class S3AsyncEncryptionClient extends DelegatingS3AsyncClient {
          * <p>If the setting is not found in any of the locations above, 'false' will be used.
          */
         public Builder fipsEnabled(Boolean isFipsEnabled) {
-            _fipsEnabled = isFipsEnabled;
+            _fipsEnabled = Optional.ofNullable(isFipsEnabled).orElse(Boolean.FALSE);
             return this;
         }
 
@@ -668,7 +669,7 @@ public class S3AsyncEncryptionClient extends DelegatingS3AsyncClient {
         }
 
         @Override
-        public S3AsyncClientBuilder serviceConfiguration(S3Configuration serviceConfiguration) {
+        public Builder serviceConfiguration(S3Configuration serviceConfiguration) {
             _serviceConfiguration = serviceConfiguration;
             return this;
         }
@@ -679,7 +680,7 @@ public class S3AsyncEncryptionClient extends DelegatingS3AsyncClient {
          * @param accelerate
          */
         @Override
-        public S3AsyncClientBuilder accelerate(Boolean accelerate) {
+        public Builder accelerate(Boolean accelerate) {
             _accelerate = accelerate;
             return this;
         }
@@ -690,7 +691,7 @@ public class S3AsyncEncryptionClient extends DelegatingS3AsyncClient {
          * @param disableMultiRegionAccessPoints
          */
         @Override
-        public S3AsyncClientBuilder disableMultiRegionAccessPoints(Boolean disableMultiRegionAccessPoints) {
+        public Builder disableMultiRegionAccessPoints(Boolean disableMultiRegionAccessPoints) {
             _disableMultiRegionAccessPoints = disableMultiRegionAccessPoints;
             return this;
         }
@@ -701,7 +702,7 @@ public class S3AsyncEncryptionClient extends DelegatingS3AsyncClient {
          * @param forcePathStyle
          */
         @Override
-        public S3AsyncClientBuilder forcePathStyle(Boolean forcePathStyle) {
+        public Builder forcePathStyle(Boolean forcePathStyle) {
             _forcePathStyle = forcePathStyle;
             return this;
         }
@@ -713,7 +714,7 @@ public class S3AsyncEncryptionClient extends DelegatingS3AsyncClient {
          * @param useArnRegion
          */
         @Override
-        public S3AsyncClientBuilder useArnRegion(Boolean useArnRegion) {
+        public Builder useArnRegion(Boolean useArnRegion) {
             _useArnRegion = useArnRegion;
             return this;
         }

--- a/src/main/java/software/amazon/encryption/s3/S3EncryptionClient.java
+++ b/src/main/java/software/amazon/encryption/s3/S3EncryptionClient.java
@@ -69,6 +69,7 @@ import java.security.SecureRandom;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.ExecutionException;
@@ -824,7 +825,7 @@ public class S3EncryptionClient extends DelegatingS3Client {
          */
         @Override
         public Builder dualstackEnabled(Boolean isDualStackEnabled) {
-            _dualStackEnabled = isDualStackEnabled;
+            _dualStackEnabled = Optional.ofNullable(isDualStackEnabled).orElse(Boolean.FALSE);
             return this;
         }
 
@@ -846,7 +847,7 @@ public class S3EncryptionClient extends DelegatingS3Client {
          */
         @Override
         public Builder fipsEnabled(Boolean isFipsEnabled) {
-            _fipsEnabled = isFipsEnabled;
+            _fipsEnabled = Optional.ofNullable(isFipsEnabled).orElse(Boolean.FALSE);
             return this;
         }
 

--- a/src/test/java/software/amazon/encryption/s3/S3EncryptionClientTest.java
+++ b/src/test/java/software/amazon/encryption/s3/S3EncryptionClientTest.java
@@ -22,12 +22,14 @@ import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
 import software.amazon.awssdk.auth.credentials.AwsSessionCredentials;
 import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
 import software.amazon.awssdk.core.ResponseBytes;
+import software.amazon.awssdk.core.client.config.ClientOverrideConfiguration;
 import software.amazon.awssdk.core.sync.RequestBody;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.kms.KmsClient;
 import software.amazon.awssdk.services.kms.model.KmsException;
 import software.amazon.awssdk.services.s3.S3AsyncClient;
 import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.S3Configuration;
 import software.amazon.awssdk.services.s3.model.CreateMultipartUploadResponse;
 import software.amazon.awssdk.services.s3.model.GetObjectResponse;
 import software.amazon.awssdk.services.s3.model.NoSuchBucketException;
@@ -740,6 +742,37 @@ public class S3EncryptionClientTest {
         deleteObject(BUCKET, objectKey, s3Client);
         wrappedClient.close();
         wrappedAsyncClient.close();
+        s3Client.close();
+    }
+
+    @Test
+    public void s3EncryptionClientTopLevelAllOptions() {
+        final String objectKey = appendTestSuffix("s3-client-with-all-top-level-options");
+        AwsCredentialsProvider creds = DefaultCredentialsProvider.create();
+        // use all top-level options;
+        // there isn't a good way to validate every option.
+        S3Client s3Client = S3EncryptionClient.builder()
+                .credentialsProvider(creds)
+                .region(Region.of(KMS_REGION.toString()))
+                .kmsKeyId(KMS_KEY_ID)
+                .dualstackEnabled(null)
+                .fipsEnabled(null)
+                .overrideConfiguration(ClientOverrideConfiguration.builder().build()) // null is ambiguous
+                .endpointOverride(null)
+                .serviceConfiguration(S3Configuration.builder().build()) // null is ambiguous
+                .accelerate(null)
+                .disableMultiRegionAccessPoints(null)
+                .forcePathStyle(null)
+                .useArnRegion(null)
+                .httpClient(null)
+                .httpClientBuilder(null)
+                .asyncHttpClient(null)
+                .asyncHttpClientBuilder(null)
+                .build();
+
+        simpleV3RoundTrip(s3Client, objectKey);
+
+        deleteObject(BUCKET, objectKey, s3Client);
         s3Client.close();
     }
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

In https://github.com/aws/amazon-s3-encryption-client-java/pull/328, the ability to configure the S3EncryptionClient and S3AsyncEncryptionClient's inner clients using the "top-level" builder was added. However, this was done based off of the more generic SDK client builder interface and thus omitted some other client configuration options specific to S3. This PR adds those extra S3-specific options to the top-level S3EC / S3AsyncEC builder. 


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

# Check any applicable:
- [ ] Were any files moved? Moving files changes their URL, which breaks all hyperlinks to the files.
