### PR TITLE
Early check for dependency when set kmsKeyId

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -75,7 +75,6 @@
       <groupId>software.amazon.awssdk</groupId>
       <artifactId>kms</artifactId>
       <version>2.28.28</version>
-      <optional>true</optional>
     </dependency>
 
     <!-- Used when enableMultipartPutObject is configured -->

--- a/src/main/java/software/amazon/encryption/s3/S3EncryptionClient.java
+++ b/src/main/java/software/amazon/encryption/s3/S3EncryptionClient.java
@@ -666,7 +666,11 @@ public class S3EncryptionClient extends DelegatingS3Client {
          * @return Returns a reference to this object so that method calls can be chained together.
          */
         public Builder kmsKeyId(String kmsKeyId) {
-            this._kmsKeyId = kmsKeyId;
+            try {
+                Class.forName("software.amazon.awssdk.services.kms.KmsClient");
+            } catch (ClassNotFoundException e) {
+                throw new RuntimeException("software.amazon.awssdk:kms is required to set up with KMS key", e);
+            }
             checkKeyOptions();
 
             return this;

--- a/src/main/java/software/amazon/encryption/s3/S3EncryptionClient.java
+++ b/src/main/java/software/amazon/encryption/s3/S3EncryptionClient.java
@@ -1139,11 +1139,6 @@ public class S3EncryptionClient extends DelegatingS3Client {
                             .secureRandom(_secureRandom)
                             .build();
                 } else if (_kmsKeyId != null) {
-                    try {
-                        Class.forName("software.amazon.awssdk.services.kms.KmsClient");
-                    } catch (ClassNotFoundException e) {
-                        throw new RuntimeException("software.amazon.awssdk:kms is required to set up with KMS key", e);
-                    }
                     KmsClient kmsClient = KmsClient.builder()
                             .credentialsProvider(_awsCredentialsProvider)
                             .region(_region)

--- a/src/main/java/software/amazon/encryption/s3/S3EncryptionClient.java
+++ b/src/main/java/software/amazon/encryption/s3/S3EncryptionClient.java
@@ -666,11 +666,7 @@ public class S3EncryptionClient extends DelegatingS3Client {
          * @return Returns a reference to this object so that method calls can be chained together.
          */
         public Builder kmsKeyId(String kmsKeyId) {
-            try {
-                Class.forName("software.amazon.awssdk.services.kms.KmsClient");
-            } catch (ClassNotFoundException e) {
-                throw new RuntimeException("software.amazon.awssdk:kms is required to set up with KMS key", e);
-            }
+            this._kmsKeyId = kmsKeyId;
             checkKeyOptions();
 
             return this;
@@ -1143,6 +1139,11 @@ public class S3EncryptionClient extends DelegatingS3Client {
                             .secureRandom(_secureRandom)
                             .build();
                 } else if (_kmsKeyId != null) {
+                    try {
+                        Class.forName("software.amazon.awssdk.services.kms.KmsClient");
+                    } catch (ClassNotFoundException e) {
+                        throw new RuntimeException("software.amazon.awssdk:kms is required to set up with KMS key", e);
+                    }
                     KmsClient kmsClient = KmsClient.builder()
                             .credentialsProvider(_awsCredentialsProvider)
                             .region(_region)


### PR DESCRIPTION
*Issue #397, if available:*
Got exception when run test and run application when provide S3EncryptionClient with kms

```bash
Caused by: java.lang.NoClassDefFoundError: software/amazon/awssdk/services/kms/KmsClient
	at software.amazon.encryption.s3.S3EncryptionClient$Builder.build(S3EncryptionClient.java:1142)
```

The root cause of the problem is that kmsClient class comes from different dependencies, while other type of security key is in the same package of the SDK.

*Description of changes:*
Check for existence of `KmsClient` class when kmsKeyId is set. 
This would help developer easier to troubleshoot the problem & take proper action

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

# Check any applicable:
- [ ] Were any files moved? Moving files changes their URL, which breaks all hyperlinks to the files.
