### PR TITLE
fix: KMS Dependency is required

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -74,8 +74,7 @@
     <dependency>
       <groupId>software.amazon.awssdk</groupId>
       <artifactId>kms</artifactId>
-      <version>2.20.38</version>
-      <optional>true</optional>
+      <version>2.28.28</version>
     </dependency>
 
     <!-- Used when enableMultipartPutObject is configured -->


### PR DESCRIPTION
*Issue #, if available:* https://github.com/aws/amazon-s3-encryption-client-java/issues/397

*Description of changes:*
KMS classes are required at runtime.
Thus, the KMS dependency is not optional.

Closes #398 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

# Check any applicable:
- [ ] Were any files moved? Moving files changes their URL, which breaks all hyperlinks to the files.
