### PR TITLE
fix: unbounded streams are not supported

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -56,7 +56,7 @@
       <dependency>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>bom</artifactId>
-        <version>2.28.28</version>
+        <version>2.29.29</version>
         <optional>true</optional>
         <type>pom</type>
         <scope>import</scope>
@@ -68,13 +68,13 @@
     <dependency>
       <groupId>software.amazon.awssdk</groupId>
       <artifactId>s3</artifactId>
-      <version>2.28.28</version>
+      <version>2.29.29</version>
     </dependency>
 
     <dependency>
       <groupId>software.amazon.awssdk</groupId>
       <artifactId>kms</artifactId>
-      <version>2.28.28</version>
+      <version>2.29.29</version>
     </dependency>
 
     <!-- Used when enableMultipartPutObject is configured -->
@@ -82,7 +82,7 @@
       <groupId>software.amazon.awssdk.crt</groupId>
       <artifactId>aws-crt</artifactId>
       <optional>true</optional>
-      <version>0.31.3</version>
+      <version>0.33.5</version>
     </dependency>
 
     <dependency>
@@ -163,7 +163,7 @@
     <dependency>
       <groupId>software.amazon.awssdk</groupId>
       <artifactId>sts</artifactId>
-      <version>2.28.28</version>
+      <version>2.29.29</version>
       <optional>true</optional>
       <scope>test</scope>
     </dependency>

--- a/src/main/java/software/amazon/encryption/s3/internal/CipherAsyncRequestBody.java
+++ b/src/main/java/software/amazon/encryption/s3/internal/CipherAsyncRequestBody.java
@@ -4,6 +4,7 @@ package software.amazon.encryption.s3.internal;
 
 import org.reactivestreams.Subscriber;
 import software.amazon.awssdk.core.async.AsyncRequestBody;
+import software.amazon.encryption.s3.S3EncryptionClientException;
 import software.amazon.encryption.s3.materials.CryptographicMaterials;
 
 import java.nio.ByteBuffer;
@@ -35,7 +36,9 @@ public class CipherAsyncRequestBody implements AsyncRequestBody {
 
     @Override
     public void subscribe(Subscriber<? super ByteBuffer> subscriber) {
-        wrappedAsyncRequestBody.subscribe(new CipherSubscriber(subscriber, contentLength().orElse(-1L), materials, iv));
+        wrappedAsyncRequestBody.subscribe(new CipherSubscriber(subscriber,
+                contentLength().orElseThrow(() -> new S3EncryptionClientException("Unbounded streams are currently not supported.")),
+                materials, iv));
     }
 
     @Override

--- a/src/main/java/software/amazon/encryption/s3/internal/PutEncryptedObjectPipeline.java
+++ b/src/main/java/software/amazon/encryption/s3/internal/PutEncryptedObjectPipeline.java
@@ -53,7 +53,7 @@ public class PutEncryptedObjectPipeline {
                 contentLength = request.contentLength();
             }
         } else {
-            contentLength = requestBody.contentLength().orElse(-1L);
+            contentLength = requestBody.contentLength().orElseThrow(() -> new S3EncryptionClientException("Unbounded streams are currently not supported."));
         }
 
         if (contentLength > AlgorithmSuite.ALG_AES_256_GCM_IV12_TAG16_NO_KDF.cipherMaxContentLengthBytes()) {

--- a/src/test/java/software/amazon/encryption/s3/S3EncryptionClientStreamTest.java
+++ b/src/test/java/software/amazon/encryption/s3/S3EncryptionClientStreamTest.java
@@ -154,7 +154,10 @@ public class S3EncryptionClientStreamTest {
 
     @Test
     public void ordinaryInputStreamV3UnboundedMultipartAsync() {
-        try (S3AsyncClient s3AsyncEncryptionClient = S3AsyncEncryptionClient.builder().aesKey(AES_KEY).enableMultipartPutObject(true).wrappedClient(s3AsyncClient).build()) {
+        try (S3AsyncClient s3AsyncEncryptionClient = S3AsyncEncryptionClient.builder()
+                .aesKey(AES_KEY)
+                .enableMultipartPutObject(true)
+                .build()) {
             final String objectKey = appendTestSuffix("ordinaryInputStreamV3UnboundedAsync");
             BlockingInputStreamAsyncRequestBody body =
                     AsyncRequestBody.forBlockingInputStream(null);
@@ -171,7 +174,11 @@ public class S3EncryptionClientStreamTest {
     @Test
     public void ordinaryInputStreamV3UnboundedCrt() {
         try (S3AsyncClient s3CrtAsyncClient = S3AsyncClient.crtCreate()) {
-            try (S3AsyncClient s3AsyncEncryptionClient = S3AsyncEncryptionClient.builder().aesKey(AES_KEY).enableMultipartPutObject(true).wrappedClient(s3CrtAsyncClient).build()) {
+            try (S3AsyncClient s3AsyncEncryptionClient = S3AsyncEncryptionClient.builder()
+                    .aesKey(AES_KEY)
+                    .enableMultipartPutObject(true)
+                    .wrappedClient(s3CrtAsyncClient)
+                    .build()) {
                 final String objectKey = appendTestSuffix("ordinaryInputStreamV3UnboundedCrt");
                 BlockingInputStreamAsyncRequestBody body =
                         AsyncRequestBody.forBlockingInputStream(null);

--- a/src/test/java/software/amazon/encryption/s3/S3EncryptionClientStreamTest.java
+++ b/src/test/java/software/amazon/encryption/s3/S3EncryptionClientStreamTest.java
@@ -17,6 +17,7 @@ import software.amazon.awssdk.core.ResponseBytes;
 import software.amazon.awssdk.core.ResponseInputStream;
 import software.amazon.awssdk.core.async.AsyncRequestBody;
 import software.amazon.awssdk.core.async.AsyncResponseTransformer;
+import software.amazon.awssdk.core.async.BlockingInputStreamAsyncRequestBody;
 import software.amazon.awssdk.core.sync.RequestBody;
 import software.amazon.awssdk.services.s3.S3AsyncClient;
 import software.amazon.awssdk.services.s3.S3Client;
@@ -24,8 +25,8 @@ import software.amazon.awssdk.services.s3.model.GetObjectResponse;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 import software.amazon.awssdk.services.s3.model.PutObjectResponse;
 import software.amazon.awssdk.utils.IoUtils;
-import software.amazon.encryption.s3.utils.BoundedStreamBufferer;
 import software.amazon.encryption.s3.utils.BoundedInputStream;
+import software.amazon.encryption.s3.utils.BoundedStreamBufferer;
 import software.amazon.encryption.s3.utils.MarkResetBoundedZerosInputStream;
 import software.amazon.encryption.s3.utils.S3EncryptionClientTestResources;
 
@@ -133,6 +134,56 @@ public class S3EncryptionClientStreamTest {
         // Cleanup
         deleteObject(BUCKET, objectKey, v3Client);
         v3Client.close();
+    }
+
+    @Test
+    public void ordinaryInputStreamV3UnboundedAsync() {
+        try (S3AsyncClient s3AsyncEncryptionClient = S3AsyncEncryptionClient.builder().aesKey(AES_KEY).build()) {
+            final String objectKey = appendTestSuffix("ordinaryInputStreamV3UnboundedAsync");
+            BlockingInputStreamAsyncRequestBody body =
+                    AsyncRequestBody.forBlockingInputStream(null);
+            try {
+                s3AsyncEncryptionClient.putObject(r -> r.bucket(BUCKET).key(objectKey), body);
+                fail("Expected exception!");
+            } catch (S3EncryptionClientException exception) {
+                // expected
+                assertTrue(exception.getMessage().contains("Unbounded streams are currently not supported"));
+            }
+        }
+    }
+
+    @Test
+    public void ordinaryInputStreamV3UnboundedMultipartAsync() {
+        try (S3AsyncClient s3AsyncEncryptionClient = S3AsyncEncryptionClient.builder().aesKey(AES_KEY).enableMultipartPutObject(true).wrappedClient(s3AsyncClient).build()) {
+            final String objectKey = appendTestSuffix("ordinaryInputStreamV3UnboundedAsync");
+            BlockingInputStreamAsyncRequestBody body =
+                    AsyncRequestBody.forBlockingInputStream(null);
+            try {
+                s3AsyncEncryptionClient.putObject(r -> r.bucket(BUCKET).key(objectKey), body);
+                fail("Expected exception!");
+            } catch (S3EncryptionClientException exception) {
+                // expected
+                assertTrue(exception.getMessage().contains("Unbounded streams are currently not supported"));
+            }
+        }
+    }
+
+    @Test
+    public void ordinaryInputStreamV3UnboundedCrt() {
+        try (S3AsyncClient s3CrtAsyncClient = S3AsyncClient.crtCreate()) {
+            try (S3AsyncClient s3AsyncEncryptionClient = S3AsyncEncryptionClient.builder().aesKey(AES_KEY).enableMultipartPutObject(true).wrappedClient(s3CrtAsyncClient).build()) {
+                final String objectKey = appendTestSuffix("ordinaryInputStreamV3UnboundedCrt");
+                BlockingInputStreamAsyncRequestBody body =
+                        AsyncRequestBody.forBlockingInputStream(null);
+                try {
+                    s3AsyncEncryptionClient.putObject(r -> r.bucket(BUCKET).key(objectKey), body);
+                    fail("Expected exception!");
+                } catch (S3EncryptionClientException exception) {
+                    // expected
+                    assertTrue(exception.getMessage().contains("Unbounded streams are currently not supported"));
+                }
+            }
+        }
     }
 
     @Test
@@ -274,9 +325,9 @@ public class S3EncryptionClientStreamTest {
         final long fileSizeExceedingDefaultLimit = 1024 * 1024 * 32 + 1;
         final InputStream largeObjectStream = new BoundedInputStream(fileSizeExceedingDefaultLimit);
         v3ClientWithBuffer32MiB.putObject(PutObjectRequest.builder()
-                                   .bucket(BUCKET)
-                                   .key(objectKey)
-                                   .build(), RequestBody.fromInputStream(largeObjectStream, fileSizeExceedingDefaultLimit));
+                .bucket(BUCKET)
+                .key(objectKey)
+                .build(), RequestBody.fromInputStream(largeObjectStream, fileSizeExceedingDefaultLimit));
 
         largeObjectStream.close();
 
@@ -327,9 +378,9 @@ public class S3EncryptionClientStreamTest {
         final InputStream largeObjectStream = new BoundedInputStream(fileSizeExceedingDefaultLimit);
         ExecutorService singleThreadExecutor = Executors.newSingleThreadExecutor();
         CompletableFuture<PutObjectResponse> futurePut = v3ClientWithBuffer32MiB.putObject(PutObjectRequest.builder()
-                                                                                           .bucket(BUCKET)
-                                                                                           .key(objectKey)
-                                                                                           .build(), AsyncRequestBody.fromInputStream(largeObjectStream, fileSizeExceedingDefaultLimit, singleThreadExecutor));
+                .bucket(BUCKET)
+                .key(objectKey)
+                .build(), AsyncRequestBody.fromInputStream(largeObjectStream, fileSizeExceedingDefaultLimit, singleThreadExecutor));
 
         futurePut.join();
         largeObjectStream.close();
@@ -387,7 +438,7 @@ public class S3EncryptionClientStreamTest {
         assertThrows(S3EncryptionClientException.class, () -> v3Client.getObjectAsBytes(builder -> builder
                 .bucket(BUCKET)
                 .key(objectKey)));
-                
+
         S3Client v3ClientWithDelayedAuth = S3EncryptionClient.builder()
                 .aesKey(AES_KEY)
                 .enableDelayedAuthenticationMode(true)


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Throw an exception for unbounded async streams.
Also updates AWS SDK dependencies,
and some minor formatting fixes. 


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

# Check any applicable:
- [ ] Were any files moved? Moving files changes their URL, which breaks all hyperlinks to the files.
