### PR TITLE
fix: treat null matdesc as empty

### DIFF
--- a/src/main/java/software/amazon/encryption/s3/internal/ContentMetadataDecodingStrategy.java
+++ b/src/main/java/software/amazon/encryption/s3/internal/ContentMetadataDecodingStrategy.java
@@ -138,7 +138,11 @@ public class ContentMetadataDecodingStrategy {
 
         // Get encrypted data key encryption context
         final Map<String, String> encryptionContext = new HashMap<>();
-        final String jsonEncryptionContext = metadata.get(MetadataKeyConstants.ENCRYPTED_DATA_KEY_CONTEXT);
+        String jsonEncryptionContext = metadata.get(MetadataKeyConstants.ENCRYPTED_DATA_KEY_CONTEXT);
+        if (jsonEncryptionContext == null) {
+            // The V2 client treats null value here as empty, do the same to avoid incompatibility
+            jsonEncryptionContext = "{}";
+        }
         // When the encryption context contains non-US-ASCII characters,
         // the S3 server applies an esoteric encoding to the object metadata.
         // Reverse that, to allow decryption.

--- a/src/main/java/software/amazon/encryption/s3/internal/ContentMetadataDecodingStrategy.java
+++ b/src/main/java/software/amazon/encryption/s3/internal/ContentMetadataDecodingStrategy.java
@@ -138,11 +138,8 @@ public class ContentMetadataDecodingStrategy {
 
         // Get encrypted data key encryption context
         final Map<String, String> encryptionContext = new HashMap<>();
-        String jsonEncryptionContext = metadata.get(MetadataKeyConstants.ENCRYPTED_DATA_KEY_CONTEXT);
-        if (jsonEncryptionContext == null) {
-            // The V2 client treats null value here as empty, do the same to avoid incompatibility
-            jsonEncryptionContext = "{}";
-        }
+        // The V2 client treats null value here as empty, do the same to avoid incompatibility
+        String jsonEncryptionContext = metadata.getOrDefault(MetadataKeyConstants.ENCRYPTED_DATA_KEY_CONTEXT, "{}");
         // When the encryption context contains non-US-ASCII characters,
         // the S3 server applies an esoteric encoding to the object metadata.
         // Reverse that, to allow decryption.


### PR DESCRIPTION
*Issue #, if available:* n/a

*Description of changes:* Apparently, in v2, the client would default to the empty map `{}` when the material description is not present. This is an edge case, but in the interest of being as compatible as possible, v3 will do the same. 


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

# Check any applicable:
- [ ] Were any files moved? Moving files changes their URL, which breaks all hyperlinks to the files.
