### PR TITLE
fix: add builders to S3EncryptionClientException class

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -56,7 +56,7 @@
       <dependency>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>bom</artifactId>
-        <version>2.30.33</version>
+        <version>2.30.32</version>
         <optional>true</optional>
         <type>pom</type>
         <scope>import</scope>
@@ -68,13 +68,13 @@
     <dependency>
       <groupId>software.amazon.awssdk</groupId>
       <artifactId>s3</artifactId>
-      <version>2.30.33</version>
+      <version>2.30.32</version>
     </dependency>
 
     <dependency>
       <groupId>software.amazon.awssdk</groupId>
       <artifactId>kms</artifactId>
-      <version>2.30.33</version>
+      <version>2.30.32</version>
     </dependency>
 
     <!-- Used when enableMultipartPutObject is configured -->
@@ -163,7 +163,7 @@
     <dependency>
       <groupId>software.amazon.awssdk</groupId>
       <artifactId>sts</artifactId>
-      <version>2.30.33</version>
+      <version>2.30.32</version>
       <optional>true</optional>
       <scope>test</scope>
     </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -56,7 +56,7 @@
       <dependency>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>bom</artifactId>
-        <version>2.30.32</version>
+        <version>2.30.38</version>
         <optional>true</optional>
         <type>pom</type>
         <scope>import</scope>
@@ -68,13 +68,13 @@
     <dependency>
       <groupId>software.amazon.awssdk</groupId>
       <artifactId>s3</artifactId>
-      <version>2.30.32</version>
+      <version>2.30.38</version>
     </dependency>
 
     <dependency>
       <groupId>software.amazon.awssdk</groupId>
       <artifactId>kms</artifactId>
-      <version>2.30.32</version>
+      <version>2.30.38</version>
     </dependency>
 
     <!-- Used when enableMultipartPutObject is configured -->
@@ -82,7 +82,7 @@
       <groupId>software.amazon.awssdk.crt</groupId>
       <artifactId>aws-crt</artifactId>
       <optional>true</optional>
-      <version>0.33.5</version>
+      <version>0.36.3</version>
     </dependency>
 
     <dependency>
@@ -163,7 +163,7 @@
     <dependency>
       <groupId>software.amazon.awssdk</groupId>
       <artifactId>sts</artifactId>
-      <version>2.30.32</version>
+      <version>2.30.38</version>
       <optional>true</optional>
       <scope>test</scope>
     </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -56,7 +56,7 @@
       <dependency>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>bom</artifactId>
-        <version>2.29.29</version>
+        <version>2.30.33</version>
         <optional>true</optional>
         <type>pom</type>
         <scope>import</scope>
@@ -68,13 +68,13 @@
     <dependency>
       <groupId>software.amazon.awssdk</groupId>
       <artifactId>s3</artifactId>
-      <version>2.29.29</version>
+      <version>2.30.33</version>
     </dependency>
 
     <dependency>
       <groupId>software.amazon.awssdk</groupId>
       <artifactId>kms</artifactId>
-      <version>2.29.29</version>
+      <version>2.30.33</version>
     </dependency>
 
     <!-- Used when enableMultipartPutObject is configured -->
@@ -163,7 +163,7 @@
     <dependency>
       <groupId>software.amazon.awssdk</groupId>
       <artifactId>sts</artifactId>
-      <version>2.29.29</version>
+      <version>2.30.33</version>
       <optional>true</optional>
       <scope>test</scope>
     </dependency>

--- a/src/main/java/software/amazon/encryption/s3/S3EncryptionClientException.java
+++ b/src/main/java/software/amazon/encryption/s3/S3EncryptionClientException.java
@@ -6,65 +6,14 @@ import software.amazon.awssdk.core.exception.SdkClientException;
 
 public class S3EncryptionClientException extends SdkClientException {
 
-    private S3EncryptionClientException(Builder b) {
-        super(b);
-    }
-
     public S3EncryptionClientException(String message) {
-        super(S3EncryptionClientException.builder()
+        super(SdkClientException.builder()
                 .message(message));
     }
 
     public S3EncryptionClientException(String message, Throwable cause) {
-        super(S3EncryptionClientException.builder()
+        super(SdkClientException.builder()
                 .message(message)
                 .cause(cause));
-    }
-
-    @Override
-    public Builder toBuilder() {
-        return new BuilderImpl(this);
-    }
-
-    public static Builder builder() {
-        return new BuilderImpl();
-    }
-
-    public interface Builder extends SdkClientException.Builder {
-        @Override
-        Builder message(String message);
-
-        @Override
-        Builder cause(Throwable cause);
-
-        @Override
-        S3EncryptionClientException build();
-    }
-
-    protected static final class BuilderImpl extends SdkClientException.BuilderImpl implements Builder {
-
-        protected BuilderImpl() {
-        }
-
-        protected BuilderImpl(S3EncryptionClientException ex) {
-            super(ex);
-        }
-
-        @Override
-        public Builder message(String message) {
-            this.message = message;
-            return this;
-        }
-
-        @Override
-        public Builder cause(Throwable cause) {
-            this.cause = cause;
-            return this;
-        }
-
-        @Override
-        public S3EncryptionClientException build() {
-            return new S3EncryptionClientException(this);
-        }
     }
 }

--- a/src/main/java/software/amazon/encryption/s3/S3EncryptionClientException.java
+++ b/src/main/java/software/amazon/encryption/s3/S3EncryptionClientException.java
@@ -11,12 +11,12 @@ public class S3EncryptionClientException extends SdkClientException {
     }
 
     public S3EncryptionClientException(String message) {
-        super(SdkClientException.builder()
+        super(S3EncryptionClientException.builder()
                 .message(message));
     }
 
     public S3EncryptionClientException(String message, Throwable cause) {
-        super(SdkClientException.builder()
+        super(S3EncryptionClientException.builder()
                 .message(message)
                 .cause(cause));
     }

--- a/src/main/java/software/amazon/encryption/s3/S3EncryptionClientException.java
+++ b/src/main/java/software/amazon/encryption/s3/S3EncryptionClientException.java
@@ -6,6 +6,10 @@ import software.amazon.awssdk.core.exception.SdkClientException;
 
 public class S3EncryptionClientException extends SdkClientException {
 
+    private S3EncryptionClientException(Builder b) {
+        super(b);
+    }
+
     public S3EncryptionClientException(String message) {
         super(SdkClientException.builder()
                 .message(message));
@@ -15,5 +19,52 @@ public class S3EncryptionClientException extends SdkClientException {
         super(SdkClientException.builder()
                 .message(message)
                 .cause(cause));
+    }
+
+    @Override
+    public Builder toBuilder() {
+        return new BuilderImpl(this);
+    }
+
+    public static Builder builder() {
+        return new BuilderImpl();
+    }
+
+    public interface Builder extends SdkClientException.Builder {
+        @Override
+        Builder message(String message);
+
+        @Override
+        Builder cause(Throwable cause);
+
+        @Override
+        S3EncryptionClientException build();
+    }
+
+    protected static final class BuilderImpl extends SdkClientException.BuilderImpl implements Builder {
+
+        protected BuilderImpl() {
+        }
+
+        protected BuilderImpl(S3EncryptionClientException ex) {
+            super(ex);
+        }
+
+        @Override
+        public Builder message(String message) {
+            this.message = message;
+            return this;
+        }
+
+        @Override
+        public Builder cause(Throwable cause) {
+            this.cause = cause;
+            return this;
+        }
+
+        @Override
+        public S3EncryptionClientException build() {
+            return new S3EncryptionClientException(this);
+        }
     }
 }

--- a/src/main/java/software/amazon/encryption/s3/S3EncryptionClientException.java
+++ b/src/main/java/software/amazon/encryption/s3/S3EncryptionClientException.java
@@ -6,14 +6,65 @@ import software.amazon.awssdk.core.exception.SdkClientException;
 
 public class S3EncryptionClientException extends SdkClientException {
 
+    private S3EncryptionClientException(Builder b) {
+        super(b);
+    }
+
     public S3EncryptionClientException(String message) {
-        super(SdkClientException.builder()
+        super(S3EncryptionClientException.builder()
                 .message(message));
     }
 
     public S3EncryptionClientException(String message, Throwable cause) {
-        super(SdkClientException.builder()
+        super(S3EncryptionClientException.builder()
                 .message(message)
                 .cause(cause));
+    }
+
+    @Override
+    public Builder toBuilder() {
+        return new BuilderImpl(this);
+    }
+
+    public static Builder builder() {
+        return new BuilderImpl();
+    }
+
+    public interface Builder extends SdkClientException.Builder {
+        @Override
+        Builder message(String message);
+
+        @Override
+        Builder cause(Throwable cause);
+
+        @Override
+        S3EncryptionClientException build();
+    }
+
+    protected static final class BuilderImpl extends SdkClientException.BuilderImpl implements Builder {
+
+        protected BuilderImpl() {
+        }
+
+        protected BuilderImpl(S3EncryptionClientException ex) {
+            super(ex);
+        }
+
+        @Override
+        public Builder message(String message) {
+            this.message = message;
+            return this;
+        }
+
+        @Override
+        public Builder cause(Throwable cause) {
+            this.cause = cause;
+            return this;
+        }
+
+        @Override
+        public S3EncryptionClientException build() {
+            return new S3EncryptionClientException(this);
+        }
     }
 }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
S3EncryptionClientException loses type due to missing builder in AWS SDK. This PR fixes it.
Fixes https://github.com/aws/amazon-s3-encryption-client-java/issues/449

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

# Check any applicable:
- [ ] Were any files moved? Moving files changes their URL, which breaks all hyperlinks to the files.
