### PR TITLE
fix: fix CipherSubscriber to only call onNext once per request

### DIFF
--- a/src/main/java/software/amazon/encryption/s3/internal/CipherSubscriber.java
+++ b/src/main/java/software/amazon/encryption/s3/internal/CipherSubscriber.java
@@ -20,7 +20,6 @@ public class CipherSubscriber implements Subscriber<ByteBuffer> {
     private final Long contentLength;
     private boolean isLastPart;
     private int tagLength;
-    private boolean onCompleteCalled = false;
 
     private byte[] outputBuffer;
 
@@ -48,33 +47,16 @@ public class CipherSubscriber implements Subscriber<ByteBuffer> {
 
     @Override
     public void onSubscribe(Subscription s) {
-        System.out.println("[CipherSubscriber] onSubscribe called with subscription: " + s);
-        wrappedSubscriber.onSubscribe(new Subscription() {
-            @Override
-            public void request(long n) {
-                System.out.println("[CipherSubscriber] Request received for " + n + " items");
-                s.request(n);
-            }
-
-            @Override
-            public void cancel() {
-                System.out.println("[CipherSubscriber] Subscription cancelled");
-                s.cancel();
-            }
-        });
+        wrappedSubscriber.onSubscribe(s);
     }
 
     @Override
     public void onNext(ByteBuffer byteBuffer) {
-        System.out.println("[CipherSubscriber] onNext called with buffer size: " + byteBuffer.remaining() + ", contentRead: " + contentRead.get() + ", contentLength: " + contentLength);
         int amountToReadFromByteBuffer = getAmountToReadFromByteBuffer(byteBuffer);
-        System.out.println("[CipherSubscriber] Amount to read from buffer: " + amountToReadFromByteBuffer);
 
         if (amountToReadFromByteBuffer > 0) {
             byte[] buf = BinaryUtils.copyBytesFrom(byteBuffer, amountToReadFromByteBuffer);
-            System.out.println("[CipherSubscriber] Copied " + buf.length + " bytes from input buffer");
             outputBuffer = cipher.update(buf, 0, amountToReadFromByteBuffer);
-            System.out.println("[CipherSubscriber] Cipher update produced " + (outputBuffer != null ? outputBuffer.length : 0) + " bytes");
 
             if (outputBuffer == null || outputBuffer.length == 0) {
                 // The underlying data is too short to fill in the block cipher.
@@ -83,14 +65,12 @@ public class CipherSubscriber implements Subscriber<ByteBuffer> {
                 // null OR length == 0.
                 if (contentRead.get() + tagLength >= contentLength) {
                     // All content has been read, so complete to get the final bytes
-                    System.out.println("[CipherSubscriber] All content read (" + contentRead.get() + " bytes), proceeding to finalBytes");
                     finalBytes();
                     return;
                 }
                 // Otherwise, wait for more bytes. To avoid blocking,
                 // send an empty buffer to the wrapped subscriber.
-                System.out.println("[CipherSubscriber] Sending empty buffer to wrapped subscriber");
-//                wrappedSubscriber.onNext(ByteBuffer.allocate(0));
+                wrappedSubscriber.onNext(ByteBuffer.allocate(0));
             } else {
                 // Check if stream has read all expected content.
                 // Once all content has been read, call onComplete.
@@ -109,23 +89,19 @@ public class CipherSubscriber implements Subscriber<ByteBuffer> {
                 // including the result of cipher.doFinal(), if applicable.
                 // Calling `wrappedSubscriber.onNext` more than once for `request(1)` 
                 // violates the Reactive Streams specification and can cause exceptions downstream.
-                System.out.println("[CipherSubscriber] Checking content read threshold: contentRead=" + contentRead.get() + ", tagLength=" + tagLength + ", contentLength=" + contentLength);
                 if (contentRead.get() + tagLength >= contentLength) {
                     // All content has been read; complete the stream.
                     // (Signalling onComplete from here is Reactive Streams-spec compliant;
                     // this class is allowed to call onComplete, even if upstream has not yet signaled onComplete.)
-                    System.out.println("[CipherSubscriber] Content read threshold reached, proceeding to finalBytes");
                     finalBytes();
                 } else {
                     // Needs to read more data, so send the data downstream,
                     // expecting that downstream will continue to request more data.
-                    System.out.println("[CipherSubscriber] Sending " + outputBuffer.length + " bytes to wrapped subscriber");
                     wrappedSubscriber.onNext(ByteBuffer.wrap(outputBuffer));
                 }
             }
         } else {
             // Do nothing
-            System.out.println("[CipherSubscriber] No data to process, forwarding buffer directly");
             wrappedSubscriber.onNext(byteBuffer);
         }
     }
@@ -134,73 +110,48 @@ public class CipherSubscriber implements Subscriber<ByteBuffer> {
         // If content length is null, we should include everything in the cipher because the stream is essentially
         // unbounded.
         if (contentLength == null) {
-            System.out.println("[CipherSubscriber] Content length is null, reading entire buffer: " + byteBuffer.remaining());
             return byteBuffer.remaining();
         }
 
         long amountReadSoFar = contentRead.getAndAdd(byteBuffer.remaining());
         long amountRemaining = Math.max(0, contentLength - amountReadSoFar);
-        System.out.println("[CipherSubscriber] Buffer read calculation - read: " + amountReadSoFar + ", remaining: " + amountRemaining + ", buffer size: " + byteBuffer.remaining());
 
         if (amountRemaining > byteBuffer.remaining()) {
-            System.out.println("[CipherSubscriber] Reading entire buffer: " + byteBuffer.remaining());
             return byteBuffer.remaining();
         } else {
-            System.out.println("[CipherSubscriber] Reading partial buffer: " + amountRemaining);
             return Math.toIntExact(amountRemaining);
         }
     }
 
     @Override
     public void onError(Throwable t) {
-        System.out.println("[CipherSubscriber] Error occurred: " + t.getMessage());
         wrappedSubscriber.onError(t);
     }
 
     @Override
     public void onComplete() {
-        System.out.println("[CipherSubscriber] onComplete called");
         wrappedSubscriber.onComplete();
     }
 
     public void finalBytes() {
-        System.out.println("[CipherSubscriber] finalBytes called, isLastPart: " + isLastPart + ", onCompleteCalled: " + onCompleteCalled);
-        // onComplete can be signalled to CipherSubscriber multiple times,
-        // but additional calls should be deduped to avoid calling onNext multiple times
-        // and raising exceptions.
-        if (onCompleteCalled) {
-            System.out.println("[CipherSubscriber] finalBytes already called, returning");
-            return;
-        }
-        onCompleteCalled = true;
-
         // If this isn't the last part, skip doFinal and just send outputBuffer downstream.
         // doFinal requires that all parts have been processed to compute the tag,
         // so the tag will only be computed when the last part is processed.
         if (!isLastPart) {
-            System.out.println("[CipherSubscriber] Not last part, sending output buffer of size: " + (outputBuffer != null ? outputBuffer.length : 0));
-            // First, propagate the bytes that were in outputBuffer downstream.
             wrappedSubscriber.onNext(ByteBuffer.wrap(outputBuffer));
-            // Then, propagate the onComplete signal downstream.
-//            wrappedSubscriber.onComplete();
             return;
         }
 
         // If this is the last part, compute doFinal and include its result in the value sent downstream.
         // The result of doFinal MUST be included with the bytes that were in outputBuffer in the final onNext call.
-        byte[] finalBytes = null;
+        byte[] finalBytes;
         try {
-            System.out.println("[CipherSubscriber] Calling cipher.doFinal()");
             finalBytes = cipher.doFinal();
-            System.out.println("[CipherSubscriber] doFinal produced " + (finalBytes != null ? finalBytes.length : 0) + " bytes");
         } catch (final GeneralSecurityException exception) {
             // Even if doFinal fails, downstream still expects to receive the bytes that were in outputBuffer
-            System.out.println("[CipherSubscriber] Security exception during doFinal: " + exception.getMessage());
             wrappedSubscriber.onNext(ByteBuffer.wrap(outputBuffer));
             // Forward error, else the wrapped subscriber waits indefinitely
             wrappedSubscriber.onError(exception);
-            // Even though doFinal failed, propagate the onComplete signal downstream
-//            wrappedSubscriber.onComplete();
             throw new S3EncryptionClientSecurityException(exception.getMessage(), exception);
         }
 
@@ -209,24 +160,18 @@ public class CipherSubscriber implements Subscriber<ByteBuffer> {
         // This single onNext call must contain both the bytes from outputBuffer and the tag.
         byte[] combinedBytes;
         if (outputBuffer != null && outputBuffer.length > 0 && finalBytes != null && finalBytes.length > 0) {
-            System.out.println("[CipherSubscriber] Combining outputBuffer (" + outputBuffer.length + " bytes) with finalBytes (" + finalBytes.length + " bytes)");
             combinedBytes = new byte[outputBuffer.length + finalBytes.length];
             System.arraycopy(outputBuffer, 0, combinedBytes, 0, outputBuffer.length);
             System.arraycopy(finalBytes, 0, combinedBytes, outputBuffer.length, finalBytes.length);
         } else if (outputBuffer != null && outputBuffer.length > 0) {
-            System.out.println("[CipherSubscriber] Using only outputBuffer (" + outputBuffer.length + " bytes)");
             combinedBytes = outputBuffer;
         } else if (finalBytes != null && finalBytes.length > 0) {
-            System.out.println("[CipherSubscriber] Using only finalBytes (" + finalBytes.length + " bytes)");
             combinedBytes = finalBytes;
         } else {
-            System.out.println("[CipherSubscriber] No bytes to send");
             combinedBytes = new byte[0];
         }
 
-        System.out.println("[CipherSubscriber] Sending combined bytes to wrapped subscriber of length " + combinedBytes.length);
         wrappedSubscriber.onNext(ByteBuffer.wrap(combinedBytes));
-//        wrappedSubscriber.onComplete();
     }
 
 }

--- a/src/main/java/software/amazon/encryption/s3/internal/CipherSubscriber.java
+++ b/src/main/java/software/amazon/encryption/s3/internal/CipherSubscriber.java
@@ -73,7 +73,6 @@ public class CipherSubscriber implements Subscriber<ByteBuffer> {
                         combinedBuffer = finalBytes;
                     }
                     wrappedSubscriber.onNext(ByteBuffer.wrap(combinedBuffer));
-                    return;
                 } else {
                     // Not at end; send content so far
                     wrappedSubscriber.onNext(ByteBuffer.wrap(outputBuffer));

--- a/src/main/java/software/amazon/encryption/s3/internal/CipherSubscriber.java
+++ b/src/main/java/software/amazon/encryption/s3/internal/CipherSubscriber.java
@@ -19,7 +19,7 @@ public class CipherSubscriber implements Subscriber<ByteBuffer> {
     private Cipher cipher;
     private final Long contentLength;
     private boolean isLastPart;
-    private boolean finalized;
+    private boolean onCompleteCalled = false;
 
     private byte[] outputBuffer;
 
@@ -28,7 +28,6 @@ public class CipherSubscriber implements Subscriber<ByteBuffer> {
         this.contentLength = contentLength;
         cipher = materials.getCipher(iv);
         this.isLastPart = isLastPart;
-        this.finalized = false;
     }
 
     CipherSubscriber(Subscriber<? super ByteBuffer> wrappedSubscriber, Long contentLength, CryptographicMaterials materials, byte[] iv) {
@@ -38,144 +37,90 @@ public class CipherSubscriber implements Subscriber<ByteBuffer> {
 
     @Override
     public void onSubscribe(Subscription s) {
-        wrappedSubscriber.onSubscribe(new Subscription() {
-            @Override
-            public void request(long n) {
-                s.request(n);
-            }
-
-            @Override
-            public void cancel() {
-                s.cancel();
-            }
-        });
+        wrappedSubscriber.onSubscribe(s);
     }
 
     @Override
     public void onNext(ByteBuffer byteBuffer) {
-        System.out.println("[CipherSubscriber] onNext called with buffer size: " + byteBuffer.remaining());
-        System.out.println("[CipherSubscriber] isLastPart: " + isLastPart);
         int amountToReadFromByteBuffer = getAmountToReadFromByteBuffer(byteBuffer);
-        System.out.println("[CipherSubscriber] amountToReadFromByteBuffer: " + amountToReadFromByteBuffer);
 
         if (amountToReadFromByteBuffer > 0) {
-            System.out.println("[CipherSubscriber] Processing chunk of size: " + amountToReadFromByteBuffer);
             byte[] buf = BinaryUtils.copyBytesFrom(byteBuffer, amountToReadFromByteBuffer);
-            System.out.println("[CipherSubscriber] Copied " + buf.length + " bytes from input buffer");
             
             outputBuffer = cipher.update(buf, 0, amountToReadFromByteBuffer);
-            System.out.println("[CipherSubscriber] Cipher update produced output buffer of length: " + (outputBuffer != null ? outputBuffer.length : 0));
 
             if (outputBuffer == null || outputBuffer.length == 0) {
-                System.out.println("[CipherSubscriber] No output from cipher update");
-                // No bytes provided from upstream; to avoid blocking, send an empty buffer to the wrapped subscriber.
+                if (contentRead.get() == contentLength) {
+                    this.onComplete();
+                }
                 wrappedSubscriber.onNext(ByteBuffer.allocate(0));
             } else {
-                boolean atEnd = isLastPart && contentRead.get() >= contentLength - 16;
-                System.out.println("[CipherSubscriber] atEnd check - isLastPart: " + isLastPart + 
-                                 ", contentRead: " + contentRead.get() + 
-                                 ", contentLength: " + contentLength + 
-                                 ", atEnd: " + atEnd);
-
-                if (atEnd) {
-                    System.out.println("[CipherSubscriber] Processing final bytes");
-                    // If all content has been read, send the final bytes in this onNext call.
-                    // The final bytes must be sent with the final onNext call, not during the onComplete call.
-                    byte[] finalBytes;
-                    try {
-                        finalBytes = cipher.doFinal();
-                        finalized = true;
-                        System.out.println("[CipherSubscriber] Cipher doFinal produced " + finalBytes.length + " bytes");
-                    } catch (final GeneralSecurityException exception) {
-                        System.out.println("[CipherSubscriber] Error during doFinal: " + exception.getMessage());
-                        wrappedSubscriber.onError(exception);
-                        throw new S3EncryptionClientSecurityException(exception.getMessage(), exception);
-                    }
-
-                    // Combine outputBuffer and finalBytes if both exist
-                    byte[] combinedBuffer;
-                    if (outputBuffer != null && outputBuffer.length > 0) {
-                        System.out.println("[CipherSubscriber] Combining outputBuffer (" + outputBuffer.length + " bytes) with finalBytes (" + finalBytes.length + " bytes)");
-                        combinedBuffer = new byte[outputBuffer.length + finalBytes.length];
-                        System.arraycopy(outputBuffer, 0, combinedBuffer, 0, outputBuffer.length);
-                        System.arraycopy(finalBytes, 0, combinedBuffer, outputBuffer.length, finalBytes.length);
-                        System.out.println("[CipherSubscriber] Combined buffer total length: " + combinedBuffer.length);
-                    } else {
-                        System.out.println("[CipherSubscriber] Using only finalBytes (" + finalBytes.length + " bytes)");
-                        combinedBuffer = finalBytes;
-                    }
-                    System.out.println("[CipherSubscriber] Sending combined buffer to wrapped subscriber");
-                    wrappedSubscriber.onNext(ByteBuffer.wrap(combinedBuffer));
-                } else {
-                    System.out.println("[CipherSubscriber] Sending " + outputBuffer.length + " bytes to wrapped subscriber");
-                    // Not at end; send content so far
+                Long amount = isLastPart ? contentLength - 31 : contentLength - 15;
+                if (contentRead.get() < amount) {
                     wrappedSubscriber.onNext(ByteBuffer.wrap(outputBuffer));
+                } else {
+                    this.onComplete();
                 }
             }
         } else {
-            System.out.println("[CipherSubscriber] No bytes to read from input buffer, forwarding original buffer");
-            // Do nothing
             wrappedSubscriber.onNext(byteBuffer);
         }
     }
 
     private int getAmountToReadFromByteBuffer(ByteBuffer byteBuffer) {
-        System.out.println("[CipherSubscriber] getAmountToReadFromByteBuffer called with buffer remaining: " + byteBuffer.remaining());
-        System.out.println("[CipherSubscriber] Current contentRead: " + contentRead.get() + ", contentLength: " + contentLength);
-
-        // If content length is null, we should include everything in the cipher because the stream is essentially
-        // unbounded.
         if (contentLength == null) {
-            System.out.println("[CipherSubscriber] No content length specified, reading entire buffer: " + byteBuffer.remaining());
             return byteBuffer.remaining();
         }
 
         long amountReadSoFar = contentRead.getAndAdd(byteBuffer.remaining());
         long amountRemaining = Math.max(0, contentLength - amountReadSoFar);
-        System.out.println("[CipherSubscriber] amountReadSoFar: " + amountReadSoFar + ", amountRemaining: " + amountRemaining);
 
         if (amountRemaining > byteBuffer.remaining()) {
-            System.out.println("[CipherSubscriber] More remaining than buffer size, reading entire buffer: " + byteBuffer.remaining());
             return byteBuffer.remaining();
         } else {
-            System.out.println("[CipherSubscriber] Reading partial buffer: " + amountRemaining);
             return Math.toIntExact(amountRemaining);
         }
     }
 
     @Override
     public void onError(Throwable t) {
-        System.out.println("[CipherSubscriber] onError called: " + t.getMessage());
         wrappedSubscriber.onError(t);
     }
 
     @Override
     public void onComplete() {
-        System.out.println("[CipherSubscriber] onComplete called, isLastPart: " + isLastPart);
-        if (!isLastPart) {
-            System.out.println("[CipherSubscriber] Not last part, skipping doFinal");
-            // If this isn't the last part, skip doFinal, we aren't done
-            wrappedSubscriber.onComplete();
+        if (onCompleteCalled) {
             return;
         }
-        if (finalized) {
-            System.out.println("[CipherSubscriber] Finalized");
+        onCompleteCalled = true;
+        if (!isLastPart) {
+            wrappedSubscriber.onNext(ByteBuffer.wrap(outputBuffer));
             wrappedSubscriber.onComplete();
             return;
         }
         try {
-            System.out.println("[CipherSubscriber] Calling cipher.doFinal()");
-            outputBuffer = cipher.doFinal();
-            System.out.println("[CipherSubscriber] doFinal produced " + (outputBuffer != null ? outputBuffer.length : 0) + " bytes");
-            // Send the final bytes to the wrapped subscriber
-            wrappedSubscriber.onNext(ByteBuffer.wrap(outputBuffer));
+            byte[] finalBytes = cipher.doFinal();
+            
+            byte[] combinedBytes;
+            if (outputBuffer != null && outputBuffer.length > 0 && finalBytes != null && finalBytes.length > 0) {
+                combinedBytes = new byte[outputBuffer.length + finalBytes.length];
+                System.arraycopy(outputBuffer, 0, combinedBytes, 0, outputBuffer.length);
+                System.arraycopy(finalBytes, 0, combinedBytes, outputBuffer.length, finalBytes.length);
+            } else if (outputBuffer != null && outputBuffer.length > 0) {
+                combinedBytes = outputBuffer;
+            } else if (finalBytes != null && finalBytes.length > 0) {
+                combinedBytes = finalBytes;
+            } else {
+                combinedBytes = new byte[0];
+            }
+            
+            if (combinedBytes.length > 0) {
+                wrappedSubscriber.onNext(ByteBuffer.wrap(combinedBytes));
+            }
         } catch (final GeneralSecurityException exception) {
-            System.out.println("[CipherSubscriber] Error during doFinal: " + exception.getMessage());
-            // Forward error, else the wrapped subscriber waits indefinitely
             wrappedSubscriber.onError(exception);
             throw new S3EncryptionClientSecurityException(exception.getMessage(), exception);
         }
-        System.out.println("[CipherSubscriber] Completing wrapped subscriber");
         wrappedSubscriber.onComplete();
     }
 

--- a/src/main/java/software/amazon/encryption/s3/internal/CipherSubscriber.java
+++ b/src/main/java/software/amazon/encryption/s3/internal/CipherSubscriber.java
@@ -11,6 +11,7 @@ import software.amazon.encryption.s3.materials.CryptographicMaterials;
 import javax.crypto.Cipher;
 import java.nio.ByteBuffer;
 import java.security.GeneralSecurityException;
+import java.util.Arrays;
 import java.util.concurrent.atomic.AtomicLong;
 
 public class CipherSubscriber implements Subscriber<ByteBuffer> {
@@ -23,6 +24,7 @@ public class CipherSubscriber implements Subscriber<ByteBuffer> {
     private byte[] outputBuffer;
 
     CipherSubscriber(Subscriber<? super ByteBuffer> wrappedSubscriber, Long contentLength, CryptographicMaterials materials, byte[] iv, boolean isLastPart) {
+        System.out.println("[CipherSubscriber] Constructor called with contentLength: " + contentLength + ", isLastPart: " + isLastPart);
         this.wrappedSubscriber = wrappedSubscriber;
         this.contentLength = contentLength;
         cipher = materials.getCipher(iv);
@@ -36,78 +38,117 @@ public class CipherSubscriber implements Subscriber<ByteBuffer> {
 
     @Override
     public void onSubscribe(Subscription s) {
-        wrappedSubscriber.onSubscribe(s);
+        System.out.println("[CipherSubscriber] onSubscribe called with subscription: " + s);
+
+        wrappedSubscriber.onSubscribe(new Subscription() {
+            @Override
+            public void request(long n) {
+                System.out.println("[CipherSubscriber] Request called for " + n + " items");
+                s.request(n);
+            }
+
+            @Override
+            public void cancel() {
+                System.out.println("[CipherSubscriber] Cancel called");
+                s.cancel();
+            }
+        });
     }
 
     @Override
     public void onNext(ByteBuffer byteBuffer) {
+        System.out.println("[CipherSubscriber] onNext called with buffer size: " + byteBuffer.remaining());
         int amountToReadFromByteBuffer = getAmountToReadFromByteBuffer(byteBuffer);
+        System.out.println("[CipherSubscriber] amountToReadFromByteBuffer: " + amountToReadFromByteBuffer);
 
         if (amountToReadFromByteBuffer > 0) {
+            System.out.println("[CipherSubscriber] Processing chunk of size: " + amountToReadFromByteBuffer);
             byte[] buf = BinaryUtils.copyBytesFrom(byteBuffer, amountToReadFromByteBuffer);
+            System.out.println("[CipherSubscriber] Copied " + buf.length + " bytes from input buffer");
+            
             outputBuffer = cipher.update(buf, 0, amountToReadFromByteBuffer);
-            if (outputBuffer == null || outputBuffer.length == 0) {
-                // No bytes provided from upstream; to avoid blocking, send an empty buffer to the wrapped subscriber.
-                wrappedSubscriber.onNext(ByteBuffer.allocate(0));
-            } else {
-                boolean atEnd = isLastPart && contentRead.get() + amountToReadFromByteBuffer >= contentLength;
+            System.out.println("[CipherSubscriber] Cipher update produced output buffer of length: " + (outputBuffer != null ? outputBuffer.length : 0));
 
-                if (atEnd) {
-                    // If all content has been read, send the final bytes in this onNext call.
-                    // The final bytes must be sent with the final onNext call, not during the onComplete call.
-                    byte[] finalBytes;
-                    try {
-                        finalBytes = cipher.doFinal();
-                    } catch (final GeneralSecurityException exception) {
-                        wrappedSubscriber.onError(exception);
-                        throw new S3EncryptionClientSecurityException(exception.getMessage(), exception);
-                    }
+            boolean atEnd = isLastPart && contentRead.get() >= contentLength - 16;
+            System.out.println("[CipherSubscriber] atEnd: " + atEnd + " (isLastPart: " + isLastPart + ", contentRead: " + contentRead.get() + ", contentLength: " + contentLength + ")");
 
-                    // Combine outputBuffer and finalBytes if both exist
-                    byte[] combinedBuffer;
-                    if (outputBuffer != null && outputBuffer.length > 0) {
-                        combinedBuffer = new byte[outputBuffer.length + finalBytes.length];
-                        System.arraycopy(outputBuffer, 0, combinedBuffer, 0, outputBuffer.length);
-                        System.arraycopy(finalBytes, 0, combinedBuffer, outputBuffer.length, finalBytes.length);
-                    } else {
-                        combinedBuffer = finalBytes;
-                    }
-                    wrappedSubscriber.onNext(ByteBuffer.wrap(combinedBuffer));
-                } else {
-                    // Not at end; send content so far
-                    wrappedSubscriber.onNext(ByteBuffer.wrap(outputBuffer));
+            if (atEnd) {
+                System.out.println("[CipherSubscriber] Processing final bytes");
+                // The final bytes must be sent with the final onNext call, not during the onComplete call.
+                byte[] finalBytes;
+                try {
+                    finalBytes = cipher.doFinal();
+                    System.out.println("[CipherSubscriber] Cipher doFinal produced " + finalBytes.length + " bytes");
+                } catch (final GeneralSecurityException exception) {
+                    System.out.println("[CipherSubscriber] Error during doFinal: " + exception.getMessage());
+                    wrappedSubscriber.onError(exception);
+                    throw new S3EncryptionClientSecurityException(exception.getMessage(), exception);
                 }
+
+                // Combine outputBuffer and finalBytes if both exist
+                byte[] combinedBuffer;
+                if (outputBuffer != null && outputBuffer.length > 0) {
+                    System.out.println("[CipherSubscriber] Combining outputBuffer (" + outputBuffer.length + " bytes) with finalBytes (" + finalBytes.length + " bytes)");
+                    combinedBuffer = new byte[outputBuffer.length + finalBytes.length];
+                    System.arraycopy(outputBuffer, 0, combinedBuffer, 0, outputBuffer.length);
+                    System.arraycopy(finalBytes, 0, combinedBuffer, outputBuffer.length, finalBytes.length);
+                    System.out.println("[CipherSubscriber] Combined buffer total length: " + combinedBuffer.length);
+                } else {
+                    System.out.println("[CipherSubscriber] Using only finalBytes (" + finalBytes.length + " bytes)");
+                    combinedBuffer = finalBytes;
+                }
+                
+                System.out.println("[CipherSubscriber] Sending combined buffer to wrapped subscriber");
+                wrappedSubscriber.onNext(ByteBuffer.wrap(combinedBuffer));
+                return;
+            } else if (outputBuffer == null || outputBuffer.length == 0) {
+                System.out.println("[CipherSubscriber] No bytes from cipher update, sending empty buffer");
+                // No bytes provided from upstream; to avoid blocking, send an empty buffer to the wrapped subscriber.
+                return;
+            } else {
+                System.out.println("[CipherSubscriber] Sending " + outputBuffer.length + " bytes to wrapped subscriber");
+                // Not at end; send content so far
+                wrappedSubscriber.onNext(ByteBuffer.wrap(outputBuffer));
             }
         } else {
-            // Do nothing
-            wrappedSubscriber.onNext(byteBuffer);
+            System.out.println("[CipherSubscriber] No bytes to read from input buffer");
+            return;
         }
     }
 
     private int getAmountToReadFromByteBuffer(ByteBuffer byteBuffer) {
+        System.out.println("[CipherSubscriber] getAmountToReadFromByteBuffer called with buffer remaining: " + byteBuffer.remaining());
+        System.out.println("[CipherSubscriber] Current contentRead: " + contentRead.get() + ", contentLength: " + contentLength);
+
         // If content length is null, we should include everything in the cipher because the stream is essentially
         // unbounded.
         if (contentLength == null) {
+            System.out.println("[CipherSubscriber] No content length specified, reading entire buffer: " + byteBuffer.remaining());
             return byteBuffer.remaining();
         }
 
         long amountReadSoFar = contentRead.getAndAdd(byteBuffer.remaining());
         long amountRemaining = Math.max(0, contentLength - amountReadSoFar);
+        System.out.println("[CipherSubscriber] amountReadSoFar: " + amountReadSoFar + ", amountRemaining: " + amountRemaining);
 
         if (amountRemaining > byteBuffer.remaining()) {
+            System.out.println("[CipherSubscriber] More remaining than buffer size, reading entire buffer: " + byteBuffer.remaining());
             return byteBuffer.remaining();
         } else {
+            System.out.println("[CipherSubscriber] Reading partial buffer: " + amountRemaining);
             return Math.toIntExact(amountRemaining);
         }
     }
 
     @Override
     public void onError(Throwable t) {
+        System.out.println("[CipherSubscriber] onError called: " + t.getMessage());
         wrappedSubscriber.onError(t);
     }
 
     @Override
     public void onComplete() {
+        System.out.println("[CipherSubscriber] onComplete called");
         wrappedSubscriber.onComplete();
     }
 

--- a/src/main/java/software/amazon/encryption/s3/internal/CipherSubscriber.java
+++ b/src/main/java/software/amazon/encryption/s3/internal/CipherSubscriber.java
@@ -20,6 +20,7 @@ public class CipherSubscriber implements Subscriber<ByteBuffer> {
     private final Long contentLength;
     private boolean isLastPart;
     private boolean onCompleteCalled = false;
+    private final AtomicLong outstandingRequests = new AtomicLong(0);
 
     private byte[] outputBuffer;
 
@@ -37,53 +38,90 @@ public class CipherSubscriber implements Subscriber<ByteBuffer> {
 
     @Override
     public void onSubscribe(Subscription s) {
-        wrappedSubscriber.onSubscribe(s);
+        System.out.println("[CipherSubscriber] onSubscribe called with subscription: " + s);
+        wrappedSubscriber.onSubscribe(new Subscription() {
+            @Override
+            public void request(long n) {
+                System.out.println("[CipherSubscriber] New request received for " + n + " items");
+                outstandingRequests.addAndGet(n);
+                System.out.println("[CipherSubscriber] Current outstanding requests: " + outstandingRequests.get());
+                s.request(n);
+            }
+
+            @Override
+            public void cancel() {
+                System.out.println("[CipherSubscriber] Subscription cancelled");
+                s.cancel();
+            }
+        });
     }
 
     @Override
     public void onNext(ByteBuffer byteBuffer) {
+        System.out.println("[CipherSubscriber] onNext called with buffer size: " + byteBuffer.remaining());
+        System.out.println("[CipherSubscriber] isLastPart: " + isLastPart);
         int amountToReadFromByteBuffer = getAmountToReadFromByteBuffer(byteBuffer);
+        System.out.println("[CipherSubscriber] amountToReadFromByteBuffer: " + amountToReadFromByteBuffer);
 
         if (amountToReadFromByteBuffer > 0) {
+            System.out.println("[CipherSubscriber] Processing chunk of size: " + amountToReadFromByteBuffer);
             byte[] buf = BinaryUtils.copyBytesFrom(byteBuffer, amountToReadFromByteBuffer);
+            System.out.println("[CipherSubscriber] Copied " + buf.length + " bytes from input buffer");
             
             outputBuffer = cipher.update(buf, 0, amountToReadFromByteBuffer);
+            System.out.println("[CipherSubscriber] Cipher update produced output buffer of length: " + (outputBuffer != null ? outputBuffer.length : 0));
 
             if (outputBuffer == null || outputBuffer.length == 0) {
+                System.out.println("[CipherSubscriber] No output from cipher update");
+                System.out.println("[CipherSubscriber] contentRead: " + contentRead.get() + ", contentLength: " + contentLength);
                 if (contentRead.get() == contentLength) {
+                    System.out.println("[CipherSubscriber] All content read (contentRead: " + contentRead.get() + ", contentLength: " + contentLength + "), calling onComplete");
                     this.onComplete();
                 }
+                System.out.println("[CipherSubscriber] Sending empty buffer to wrapped subscriber");
                 wrappedSubscriber.onNext(ByteBuffer.allocate(0));
             } else {
+                System.out.println("[CipherSubscriber] Sending " + outputBuffer.length + " bytes to wrapped subscriber");
+                System.out.println("[CipherSubscriber] contentRead: " + contentRead.get() + ", contentLength: " + contentLength);
                 Long amount = isLastPart ? contentLength - 31 : contentLength - 15;
                 if (contentRead.get() < amount) {
                     wrappedSubscriber.onNext(ByteBuffer.wrap(outputBuffer));
                 } else {
+                    System.out.println("[CipherSubscriber] All content read (contentRead: " + contentRead.get() + ", contentLength: " + contentLength + "), calling onComplete");
                     this.onComplete();
                 }
             }
         } else {
+            System.out.println("[CipherSubscriber] No bytes to read from input buffer, forwarding original buffer");
             wrappedSubscriber.onNext(byteBuffer);
         }
     }
 
     private int getAmountToReadFromByteBuffer(ByteBuffer byteBuffer) {
+        System.out.println("[CipherSubscriber] getAmountToReadFromByteBuffer called with buffer remaining: " + byteBuffer.remaining());
+        System.out.println("[CipherSubscriber] Current contentRead: " + contentRead.get() + ", contentLength: " + contentLength);
+
         if (contentLength == null) {
+            System.out.println("[CipherSubscriber] No content length specified, reading entire buffer: " + byteBuffer.remaining());
             return byteBuffer.remaining();
         }
 
         long amountReadSoFar = contentRead.getAndAdd(byteBuffer.remaining());
         long amountRemaining = Math.max(0, contentLength - amountReadSoFar);
+        System.out.println("[CipherSubscriber] amountReadSoFar: " + amountReadSoFar + ", amountRemaining: " + amountRemaining);
 
         if (amountRemaining > byteBuffer.remaining()) {
+            System.out.println("[CipherSubscriber] More remaining than buffer size, reading entire buffer: " + byteBuffer.remaining());
             return byteBuffer.remaining();
         } else {
+            System.out.println("[CipherSubscriber] Reading partial buffer: " + amountRemaining);
             return Math.toIntExact(amountRemaining);
         }
     }
 
     @Override
     public void onError(Throwable t) {
+        System.out.println("[CipherSubscriber] onError called: " + t.getMessage());
         wrappedSubscriber.onError(t);
     }
 
@@ -93,34 +131,45 @@ public class CipherSubscriber implements Subscriber<ByteBuffer> {
             return;
         }
         onCompleteCalled = true;
+        System.out.println("[CipherSubscriber] onComplete called, isLastPart: " + isLastPart);
         if (!isLastPart) {
+            System.out.println("[CipherSubscriber] Not last part, skipping doFinal");
             wrappedSubscriber.onNext(ByteBuffer.wrap(outputBuffer));
             wrappedSubscriber.onComplete();
             return;
         }
         try {
+            System.out.println("[CipherSubscriber] Calling cipher.doFinal()");
             byte[] finalBytes = cipher.doFinal();
+            System.out.println("[CipherSubscriber] doFinal produced " + (finalBytes != null ? finalBytes.length : 0) + " bytes");
             
             byte[] combinedBytes;
             if (outputBuffer != null && outputBuffer.length > 0 && finalBytes != null && finalBytes.length > 0) {
+                System.out.println("[CipherSubscriber] Combining outputBuffer (" + outputBuffer.length + " bytes) with finalBytes (" + finalBytes.length + " bytes)");
                 combinedBytes = new byte[outputBuffer.length + finalBytes.length];
                 System.arraycopy(outputBuffer, 0, combinedBytes, 0, outputBuffer.length);
                 System.arraycopy(finalBytes, 0, combinedBytes, outputBuffer.length, finalBytes.length);
             } else if (outputBuffer != null && outputBuffer.length > 0) {
+                System.out.println("[CipherSubscriber] Using only outputBuffer (" + outputBuffer.length + " bytes)");
                 combinedBytes = outputBuffer;
             } else if (finalBytes != null && finalBytes.length > 0) {
+                System.out.println("[CipherSubscriber] Using only finalBytes (" + finalBytes.length + " bytes)");
                 combinedBytes = finalBytes;
             } else {
+                System.out.println("[CipherSubscriber] No bytes to send");
                 combinedBytes = new byte[0];
             }
             
             if (combinedBytes.length > 0) {
+                System.out.println("[CipherSubscriber] Sending combined bytes to wrapped subscriber of length " + combinedBytes.length);
                 wrappedSubscriber.onNext(ByteBuffer.wrap(combinedBytes));
             }
         } catch (final GeneralSecurityException exception) {
+            System.out.println("[CipherSubscriber] Error during doFinal: " + exception.getMessage());
             wrappedSubscriber.onError(exception);
             throw new S3EncryptionClientSecurityException(exception.getMessage(), exception);
         }
+        System.out.println("[CipherSubscriber] Completing wrapped subscriber");
         wrappedSubscriber.onComplete();
     }
 

--- a/src/main/java/software/amazon/encryption/s3/internal/CipherSubscriber.java
+++ b/src/main/java/software/amazon/encryption/s3/internal/CipherSubscriber.java
@@ -47,16 +47,33 @@ public class CipherSubscriber implements Subscriber<ByteBuffer> {
 
     @Override
     public void onSubscribe(Subscription s) {
-        wrappedSubscriber.onSubscribe(s);
+        //System.out.println("[CipherSubscriber] onSubscribe called with subscription: " + s);
+        wrappedSubscriber.onSubscribe(new Subscription() {
+            @Override
+            public void request(long n) {
+                //System.out.println("[CipherSubscriber] Request received for " + n + " items");
+                s.request(n);
+            }
+
+            @Override
+            public void cancel() {
+                //System.out.println("[CipherSubscriber] Subscription cancelled");
+                s.cancel();
+            }
+        });
     }
 
     @Override
     public void onNext(ByteBuffer byteBuffer) {
+        //System.out.println("[CipherSubscriber] onNext called with buffer size: " + byteBuffer.remaining() + ", contentRead: " + contentRead.get() + ", contentLength: " + contentLength);
         int amountToReadFromByteBuffer = getAmountToReadFromByteBuffer(byteBuffer);
+        //System.out.println("[CipherSubscriber] Amount to read from buffer: " + amountToReadFromByteBuffer);
 
         if (amountToReadFromByteBuffer > 0) {
             byte[] buf = BinaryUtils.copyBytesFrom(byteBuffer, amountToReadFromByteBuffer);
+            //System.out.println("[CipherSubscriber] Copied " + buf.length + " bytes from input buffer");
             outputBuffer = cipher.update(buf, 0, amountToReadFromByteBuffer);
+            //System.out.println("[CipherSubscriber] Cipher update produced " + (outputBuffer != null ? outputBuffer.length : 0) + " bytes");
 
             if (outputBuffer == null || outputBuffer.length == 0) {
                 // The underlying data is too short to fill in the block cipher.
@@ -65,11 +82,13 @@ public class CipherSubscriber implements Subscriber<ByteBuffer> {
                 // null OR length == 0.
                 if (contentRead.get() + tagLength >= contentLength) {
                     // All content has been read, so complete to get the final bytes
+                    //System.out.println("[CipherSubscriber] All content read (" + contentRead.get() + " bytes), proceeding to finalBytes");
                     finalBytes();
                     return;
                 }
                 // Otherwise, wait for more bytes. To avoid blocking,
                 // send an empty buffer to the wrapped subscriber.
+                //System.out.println("[CipherSubscriber] Sending empty buffer to wrapped subscriber");
                 wrappedSubscriber.onNext(ByteBuffer.allocate(0));
             } else {
                 // Check if stream has read all expected content.
@@ -89,19 +108,23 @@ public class CipherSubscriber implements Subscriber<ByteBuffer> {
                 // including the result of cipher.doFinal(), if applicable.
                 // Calling `wrappedSubscriber.onNext` more than once for `request(1)` 
                 // violates the Reactive Streams specification and can cause exceptions downstream.
+                //System.out.println("[CipherSubscriber] Checking content read threshold: contentRead=" + contentRead.get() + ", tagLength=" + tagLength + ", contentLength=" + contentLength);
                 if (contentRead.get() + tagLength >= contentLength) {
                     // All content has been read; complete the stream.
                     // (Signalling onComplete from here is Reactive Streams-spec compliant;
                     // this class is allowed to call onComplete, even if upstream has not yet signaled onComplete.)
+                    //System.out.println("[CipherSubscriber] Content read threshold (" + contentRead.get() + ") reached, proceeding to finalBytes");
                     finalBytes();
                 } else {
                     // Needs to read more data, so send the data downstream,
                     // expecting that downstream will continue to request more data.
+                    //System.out.println("[CipherSubscriber] Sending " + outputBuffer.length + " bytes to wrapped subscriber");
                     wrappedSubscriber.onNext(ByteBuffer.wrap(outputBuffer));
                 }
             }
         } else {
             // Do nothing
+            //System.out.println("[CipherSubscriber] No data to process, forwarding buffer directly");
             wrappedSubscriber.onNext(byteBuffer);
         }
     }
@@ -110,26 +133,38 @@ public class CipherSubscriber implements Subscriber<ByteBuffer> {
         // If content length is null, we should include everything in the cipher because the stream is essentially
         // unbounded.
         if (contentLength == null) {
+            //System.out.println("[CipherSubscriber] Content length is null, reading entire buffer: " + byteBuffer.remaining());
             return byteBuffer.remaining();
         }
 
         long amountReadSoFar = contentRead.getAndAdd(byteBuffer.remaining());
         long amountRemaining = Math.max(0, contentLength - amountReadSoFar);
+        //System.out.println("[CipherSubscriber] Buffer read calculation - read: " + amountReadSoFar + ", remaining: " + amountRemaining + ", buffer size: " + byteBuffer.remaining());
 
         if (amountRemaining > byteBuffer.remaining()) {
+            //System.out.println("[CipherSubscriber] Reading entire buffer: " + byteBuffer.remaining());
             return byteBuffer.remaining();
         } else {
+            //System.out.println("[CipherSubscriber] Reading partial buffer: " + amountRemaining);
             return Math.toIntExact(amountRemaining);
         }
     }
 
     @Override
     public void onError(Throwable t) {
+        //System.out.println("[CipherSubscriber] Error occurred: " + t.getMessage());
         wrappedSubscriber.onError(t);
     }
 
     @Override
     public void onComplete() {
+        //System.out.println("[CipherSubscriber] onComplete called");
+        if (contentRead.get() < contentLength) {
+            //System.out.println("[CipherSubscriber] onComplete called prematurely! The content read is " + contentRead.get() + " but the contentLength is " + contentLength);
+            //System.out.println("try just calling finalBytes() straight up");
+            finalBytes();
+            //System.out.println("now let it complete");
+        }
         wrappedSubscriber.onComplete();
     }
 
@@ -137,7 +172,9 @@ public class CipherSubscriber implements Subscriber<ByteBuffer> {
         // If this isn't the last part, skip doFinal and just send outputBuffer downstream.
         // doFinal requires that all parts have been processed to compute the tag,
         // so the tag will only be computed when the last part is processed.
+        //System.out.println("[CipherSubscriber] finalBytes called, isLastPart: " + isLastPart);
         if (!isLastPart) {
+            //System.out.println("[CipherSubscriber] Not last part, sending output buffer of size: " + (outputBuffer != null ? outputBuffer.length : 0));
             wrappedSubscriber.onNext(ByteBuffer.wrap(outputBuffer));
             return;
         }
@@ -146,9 +183,11 @@ public class CipherSubscriber implements Subscriber<ByteBuffer> {
         // The result of doFinal MUST be included with the bytes that were in outputBuffer in the final onNext call.
         byte[] finalBytes;
         try {
+            //System.out.println("[CipherSubscriber] Calling cipher.doFinal()");
             finalBytes = cipher.doFinal();
         } catch (final GeneralSecurityException exception) {
             // Even if doFinal fails, downstream still expects to receive the bytes that were in outputBuffer
+            //System.out.println("[CipherSubscriber] Security exception during doFinal: " + exception.getMessage());
             wrappedSubscriber.onNext(ByteBuffer.wrap(outputBuffer));
             // Forward error, else the wrapped subscriber waits indefinitely
             wrappedSubscriber.onError(exception);
@@ -160,17 +199,22 @@ public class CipherSubscriber implements Subscriber<ByteBuffer> {
         // This single onNext call must contain both the bytes from outputBuffer and the tag.
         byte[] combinedBytes;
         if (outputBuffer != null && outputBuffer.length > 0 && finalBytes != null && finalBytes.length > 0) {
+            //System.out.println("[CipherSubscriber] Combining outputBuffer (" + outputBuffer.length + " bytes) with finalBytes (" + finalBytes.length + " bytes)");
             combinedBytes = new byte[outputBuffer.length + finalBytes.length];
             System.arraycopy(outputBuffer, 0, combinedBytes, 0, outputBuffer.length);
             System.arraycopy(finalBytes, 0, combinedBytes, outputBuffer.length, finalBytes.length);
         } else if (outputBuffer != null && outputBuffer.length > 0) {
+            //System.out.println("[CipherSubscriber] Using only outputBuffer (" + outputBuffer.length + " bytes)");
             combinedBytes = outputBuffer;
         } else if (finalBytes != null && finalBytes.length > 0) {
+            //System.out.println("[CipherSubscriber] Using only finalBytes (" + finalBytes.length + " bytes)");
             combinedBytes = finalBytes;
         } else {
+            //System.out.println("[CipherSubscriber] No bytes to send");
             combinedBytes = new byte[0];
         }
 
+        //System.out.println("[CipherSubscriber] Sending combined bytes to wrapped subscriber of length " + combinedBytes.length);
         wrappedSubscriber.onNext(ByteBuffer.wrap(combinedBytes));
     }
 

--- a/src/main/java/software/amazon/encryption/s3/internal/CipherSubscriber.java
+++ b/src/main/java/software/amazon/encryption/s3/internal/CipherSubscriber.java
@@ -20,7 +20,6 @@ public class CipherSubscriber implements Subscriber<ByteBuffer> {
     private final Long contentLength;
     private boolean isLastPart;
     private boolean onCompleteCalled = false;
-    private final AtomicLong outstandingRequests = new AtomicLong(0);
 
     private byte[] outputBuffer;
 
@@ -38,95 +37,62 @@ public class CipherSubscriber implements Subscriber<ByteBuffer> {
 
     @Override
     public void onSubscribe(Subscription s) {
-        System.out.println("[CipherSubscriber] onSubscribe called with subscription: " + s);
-        wrappedSubscriber.onSubscribe(new Subscription() {
-            @Override
-            public void request(long n) {
-                System.out.println("[CipherSubscriber] New request received for " + n + " items");
-                outstandingRequests.addAndGet(n);
-                System.out.println("[CipherSubscriber] Current outstanding requests: " + outstandingRequests.get());
-                s.request(n);
-            }
-
-            @Override
-            public void cancel() {
-                System.out.println("[CipherSubscriber] Subscription cancelled");
-                s.cancel();
-            }
-        });
+        wrappedSubscriber.onSubscribe(s);
     }
 
     @Override
     public void onNext(ByteBuffer byteBuffer) {
-        System.out.println("[CipherSubscriber] ByteBuffer content: " + byteBuffer.toString());
-//        while (byteBuffer.hasRemaining()) {
-//            byte b = byteBuffer.get();
-//            System.out.printf("%02x ", b); // Print as hex
-//        }
-        System.out.println("[CipherSubscriber] onNext called with buffer size: " + byteBuffer.remaining());
-        System.out.println("[CipherSubscriber] isLastPart: " + isLastPart);
         int amountToReadFromByteBuffer = getAmountToReadFromByteBuffer(byteBuffer);
-        System.out.println("[CipherSubscriber] amountToReadFromByteBuffer: " + amountToReadFromByteBuffer);
 
         if (amountToReadFromByteBuffer > 0) {
-            System.out.println("[CipherSubscriber] Processing chunk of size: " + amountToReadFromByteBuffer);
             byte[] buf = BinaryUtils.copyBytesFrom(byteBuffer, amountToReadFromByteBuffer);
-            System.out.println("[CipherSubscriber] Copied " + buf.length + " bytes from input buffer");
-
             outputBuffer = cipher.update(buf, 0, amountToReadFromByteBuffer);
-            System.out.println("[CipherSubscriber] Cipher update produced output buffer of length: " + (outputBuffer != null ? outputBuffer.length : 0));
-
             if (outputBuffer == null || outputBuffer.length == 0) {
-                System.out.println("[CipherSubscriber] No output from cipher update");
-                System.out.println("[CipherSubscriber] contentRead: " + contentRead.get() + ", contentLength: " + contentLength);
+                // The underlying data is too short to fill in the block cipher.
+                // Note that while the JCE Javadoc specifies that the outputBuffer is null in this case,
+                // in practice SunJCE and ACCP return an empty buffer instead, hence checks for
+                // null OR length == 0.
                 if (contentRead.get() == contentLength) {
-                    System.out.println("[CipherSubscriber] All content read (contentRead: " + contentRead.get() + ", contentLength: " + contentLength + "), calling onComplete");
+                    // All content has been read, so complete to get the final bytes
                     this.onComplete();
                 }
-                System.out.println("[CipherSubscriber] Sending empty buffer to wrapped subscriber");
+                // Otherwise, wait for more bytes. To avoid blocking,
+                // send an empty buffer to the wrapped subscriber.
                 wrappedSubscriber.onNext(ByteBuffer.allocate(0));
             } else {
-                System.out.println("[CipherSubscriber] Sending " + outputBuffer.length + " bytes to wrapped subscriber");
-                System.out.println("[CipherSubscriber] contentRead: " + contentRead.get() + ", contentLength: " + contentLength);
                 Long amount = isLastPart ? contentLength - 31 : contentLength - 15;
                 if (contentRead.get() < amount) {
                     wrappedSubscriber.onNext(ByteBuffer.wrap(outputBuffer));
                 } else {
+                    // Done, wait for upstream to signal onComplete
                     System.out.println("[CipherSubscriber] All content read (contentRead: " + contentRead.get() + ", contentLength: " + contentLength + "), waiting for onComplete");
-//                    this.onComplete();
                 }
             }
         } else {
-            System.out.println("[CipherSubscriber] No bytes to read from input buffer, forwarding original buffer");
+            // Do nothing
             wrappedSubscriber.onNext(byteBuffer);
         }
     }
 
     private int getAmountToReadFromByteBuffer(ByteBuffer byteBuffer) {
-        System.out.println("[CipherSubscriber] getAmountToReadFromByteBuffer called with buffer remaining: " + byteBuffer.remaining());
-        System.out.println("[CipherSubscriber] Current contentRead: " + contentRead.get() + ", contentLength: " + contentLength);
-
+        // If content length is null, we should include everything in the cipher because the stream is essentially
+        // unbounded.
         if (contentLength == null) {
-            System.out.println("[CipherSubscriber] No content length specified, reading entire buffer: " + byteBuffer.remaining());
             return byteBuffer.remaining();
         }
 
         long amountReadSoFar = contentRead.getAndAdd(byteBuffer.remaining());
         long amountRemaining = Math.max(0, contentLength - amountReadSoFar);
-        System.out.println("[CipherSubscriber] amountReadSoFar: " + amountReadSoFar + ", amountRemaining: " + amountRemaining);
 
         if (amountRemaining > byteBuffer.remaining()) {
-            System.out.println("[CipherSubscriber] More remaining than buffer size, reading entire buffer: " + byteBuffer.remaining());
             return byteBuffer.remaining();
         } else {
-            System.out.println("[CipherSubscriber] Reading partial buffer: " + amountRemaining);
             return Math.toIntExact(amountRemaining);
         }
     }
 
     @Override
     public void onError(Throwable t) {
-        System.out.println("[CipherSubscriber] onError called: " + t.getMessage());
         wrappedSubscriber.onError(t);
     }
 
@@ -136,47 +102,39 @@ public class CipherSubscriber implements Subscriber<ByteBuffer> {
             return;
         }
         onCompleteCalled = true;
-        System.out.println("[CipherSubscriber] onComplete called, isLastPart: " + isLastPart);
         if (!isLastPart) {
-            System.out.println("[CipherSubscriber] Not last part, skipping doFinal");
+            // If this isn't the last part, skip doFinal, we aren't done
             wrappedSubscriber.onNext(ByteBuffer.wrap(outputBuffer));
             wrappedSubscriber.onComplete();
             return;
         }
-        byte[] finalBytes;
         try {
-            System.out.println("[CipherSubscriber] Calling cipher.doFinal()");
-            finalBytes = cipher.doFinal();
+            byte[] finalBytes = cipher.doFinal();
+
+            byte[] combinedBytes;
+            if (outputBuffer != null && outputBuffer.length > 0 && finalBytes != null && finalBytes.length > 0) {
+                combinedBytes = new byte[outputBuffer.length + finalBytes.length];
+                System.arraycopy(outputBuffer, 0, combinedBytes, 0, outputBuffer.length);
+                System.arraycopy(finalBytes, 0, combinedBytes, outputBuffer.length, finalBytes.length);
+            } else if (outputBuffer != null && outputBuffer.length > 0) {
+                combinedBytes = outputBuffer;
+            } else if (finalBytes != null && finalBytes.length > 0) {
+                combinedBytes = finalBytes;
+            } else {
+                combinedBytes = new byte[0];
+            }
+
+            if (combinedBytes.length > 0) {
+                wrappedSubscriber.onNext(ByteBuffer.wrap(combinedBytes));
+            }
+            wrappedSubscriber.onComplete();
         } catch (final GeneralSecurityException exception) {
-            System.out.println("[CipherSubscriber] Error during doFinal: " + exception.getMessage());
+            // Forward error, else the wrapped subscriber waits indefinitely
+            wrappedSubscriber.onNext(ByteBuffer.wrap(outputBuffer));
             wrappedSubscriber.onError(exception);
+            wrappedSubscriber.onComplete();
             throw new S3EncryptionClientSecurityException(exception.getMessage(), exception);
         }
-        System.out.println("[CipherSubscriber] doFinal produced " + (finalBytes != null ? finalBytes.length : 0) + " bytes");
-
-        byte[] combinedBytes;
-        if (outputBuffer != null && outputBuffer.length > 0 && finalBytes != null && finalBytes.length > 0) {
-            System.out.println("[CipherSubscriber] Combining outputBuffer (" + outputBuffer.length + " bytes) with finalBytes (" + finalBytes.length + " bytes)");
-            combinedBytes = new byte[outputBuffer.length + finalBytes.length];
-            System.arraycopy(outputBuffer, 0, combinedBytes, 0, outputBuffer.length);
-            System.arraycopy(finalBytes, 0, combinedBytes, outputBuffer.length, finalBytes.length);
-        } else if (outputBuffer != null && outputBuffer.length > 0) {
-            System.out.println("[CipherSubscriber] Using only outputBuffer (" + outputBuffer.length + " bytes)");
-            combinedBytes = outputBuffer;
-        } else if (finalBytes != null && finalBytes.length > 0) {
-            System.out.println("[CipherSubscriber] Using only finalBytes (" + finalBytes.length + " bytes)");
-            combinedBytes = finalBytes;
-        } else {
-            System.out.println("[CipherSubscriber] No bytes to send");
-            combinedBytes = new byte[0];
-        }
-
-        if (combinedBytes.length > 0) {
-            System.out.println("[CipherSubscriber] Sending combined bytes to wrapped subscriber of length " + combinedBytes.length);
-            wrappedSubscriber.onNext(ByteBuffer.wrap(combinedBytes));
-        }
-        System.out.println("[CipherSubscriber] Completing wrapped subscriber");
-        wrappedSubscriber.onComplete();
     }
 
 }

--- a/src/main/java/software/amazon/encryption/s3/internal/CipherSubscriber.java
+++ b/src/main/java/software/amazon/encryption/s3/internal/CipherSubscriber.java
@@ -67,7 +67,7 @@ public class CipherSubscriber implements Subscriber<ByteBuffer> {
             } else {
                 /*
                  Check if stream has read all expected content.
-                 Once all content has been read, call onComplete.
+                 Once all content has been read, call `finalBytes`.
 
                  This determines that all content has been read by checking if
                  the amount of data read so far plus the tag length is at least the content length.
@@ -86,8 +86,6 @@ public class CipherSubscriber implements Subscriber<ByteBuffer> {
                 */
                 if (contentRead.get() + tagLength >= contentLength) {
                     // All content has been read; complete the stream.
-                    // (Signalling onComplete from here is Reactive Streams-spec compliant;
-                    // this class is allowed to call onComplete, even if upstream has not yet signaled onComplete.)
                     finalBytes();
                 } else {
                     // Needs to read more data, so send the data downstream,
@@ -127,7 +125,7 @@ public class CipherSubscriber implements Subscriber<ByteBuffer> {
     public void onComplete() {
         // In rare cases, e.g. when the last part of a low-level MPU has 0 length,
         // onComplete will be called before onNext is called once.
-        if (contentRead.get() < contentLength) {
+        if (contentRead.get() + tagLength <= contentLength) {
             finalBytes();
         }
         wrappedSubscriber.onComplete();

--- a/src/main/java/software/amazon/encryption/s3/internal/CipherSubscriber.java
+++ b/src/main/java/software/amazon/encryption/s3/internal/CipherSubscriber.java
@@ -63,7 +63,7 @@ public class CipherSubscriber implements Subscriber<ByteBuffer> {
                 // No bytes provided from upstream; to avoid blocking, send an empty buffer to the wrapped subscriber.
                 wrappedSubscriber.onNext(ByteBuffer.allocate(0));
             } else {
-                boolean atEnd = isLastPart && contentRead.get() + amountToReadFromByteBuffer >= contentLength;
+                boolean atEnd = isLastPart && contentRead.get() >= contentLength;
 
                 if (atEnd) {
                     // If all content has been read, send the final bytes in this onNext call.

--- a/src/main/java/software/amazon/encryption/s3/internal/CipherSubscriber.java
+++ b/src/main/java/software/amazon/encryption/s3/internal/CipherSubscriber.java
@@ -47,17 +47,7 @@ public class CipherSubscriber implements Subscriber<ByteBuffer> {
 
     @Override
     public void onSubscribe(Subscription s) {
-        wrappedSubscriber.onSubscribe(new Subscription() {
-            @Override
-            public void request(long n) {
-                s.request(n);
-            }
-
-            @Override
-            public void cancel() {
-                s.cancel();
-            }
-        });
+        wrappedSubscriber.onSubscribe(s);
     }
 
     @Override

--- a/src/main/java/software/amazon/encryption/s3/internal/CipherSubscriber.java
+++ b/src/main/java/software/amazon/encryption/s3/internal/CipherSubscriber.java
@@ -48,29 +48,49 @@ public class CipherSubscriber implements Subscriber<ByteBuffer> {
 
     @Override
     public void onSubscribe(Subscription s) {
-        wrappedSubscriber.onSubscribe(s);
+        System.out.println("[CipherSubscriber] onSubscribe called with subscription: " + s);
+        wrappedSubscriber.onSubscribe(new Subscription() {
+            @Override
+            public void request(long n) {
+                System.out.println("[CipherSubscriber] Request received for " + n + " items");
+                s.request(n);
+            }
+
+            @Override
+            public void cancel() {
+                System.out.println("[CipherSubscriber] Subscription cancelled");
+                s.cancel();
+            }
+        });
     }
 
     @Override
     public void onNext(ByteBuffer byteBuffer) {
+        System.out.println("[CipherSubscriber] onNext called with buffer size: " + byteBuffer.remaining() + ", contentRead: " + contentRead.get() + ", contentLength: " + contentLength);
         int amountToReadFromByteBuffer = getAmountToReadFromByteBuffer(byteBuffer);
+        System.out.println("[CipherSubscriber] Amount to read from buffer: " + amountToReadFromByteBuffer);
 
         if (amountToReadFromByteBuffer > 0) {
             byte[] buf = BinaryUtils.copyBytesFrom(byteBuffer, amountToReadFromByteBuffer);
+            System.out.println("[CipherSubscriber] Copied " + buf.length + " bytes from input buffer");
             outputBuffer = cipher.update(buf, 0, amountToReadFromByteBuffer);
+            System.out.println("[CipherSubscriber] Cipher update produced " + (outputBuffer != null ? outputBuffer.length : 0) + " bytes");
 
             if (outputBuffer == null || outputBuffer.length == 0) {
                 // The underlying data is too short to fill in the block cipher.
                 // Note that while the JCE Javadoc specifies that the outputBuffer is null in this case,
                 // in practice SunJCE and ACCP return an empty buffer instead, hence checks for
                 // null OR length == 0.
-                if (contentRead.get() == contentLength) {
+                if (contentRead.get() + tagLength >= contentLength) {
                     // All content has been read, so complete to get the final bytes
-                    this.onComplete();
+                    System.out.println("[CipherSubscriber] All content read (" + contentRead.get() + " bytes), proceeding to finalBytes");
+                    finalBytes();
+                    return;
                 }
                 // Otherwise, wait for more bytes. To avoid blocking,
                 // send an empty buffer to the wrapped subscriber.
-                wrappedSubscriber.onNext(ByteBuffer.allocate(0));
+                System.out.println("[CipherSubscriber] Sending empty buffer to wrapped subscriber");
+//                wrappedSubscriber.onNext(ByteBuffer.allocate(0));
             } else {
                 // Check if stream has read all expected content.
                 // Once all content has been read, call onComplete.
@@ -80,7 +100,7 @@ public class CipherSubscriber implements Subscriber<ByteBuffer> {
                 // Once this is true, downstream will never call `request` again
                 // (beyond the current request that is being responded to in this onNext invocation.)
                 // As a result, this class can only call `wrappedSubscriber.onNext` one more time.
-                // (Reactive streams require that downstream sends a `request(n)` 
+                // (Reactive streams require that downstream sends a `request(n)`
                 // to indicate it is ready for more data, and upstream responds to that request by calling `onNext`.
                 // The `n` in request is the maximum number of `onNext` calls that downstream 
                 // will allow upstream to make, and seems to always be 1 for the AsyncBodySubscriber.)
@@ -89,19 +109,23 @@ public class CipherSubscriber implements Subscriber<ByteBuffer> {
                 // including the result of cipher.doFinal(), if applicable.
                 // Calling `wrappedSubscriber.onNext` more than once for `request(1)` 
                 // violates the Reactive Streams specification and can cause exceptions downstream.
+                System.out.println("[CipherSubscriber] Checking content read threshold: contentRead=" + contentRead.get() + ", tagLength=" + tagLength + ", contentLength=" + contentLength);
                 if (contentRead.get() + tagLength >= contentLength) {
                     // All content has been read; complete the stream.
                     // (Signalling onComplete from here is Reactive Streams-spec compliant;
                     // this class is allowed to call onComplete, even if upstream has not yet signaled onComplete.)
-                    this.onComplete();
+                    System.out.println("[CipherSubscriber] Content read threshold reached, proceeding to finalBytes");
+                    finalBytes();
                 } else {
                     // Needs to read more data, so send the data downstream,
                     // expecting that downstream will continue to request more data.
+                    System.out.println("[CipherSubscriber] Sending " + outputBuffer.length + " bytes to wrapped subscriber");
                     wrappedSubscriber.onNext(ByteBuffer.wrap(outputBuffer));
                 }
             }
         } else {
             // Do nothing
+            System.out.println("[CipherSubscriber] No data to process, forwarding buffer directly");
             wrappedSubscriber.onNext(byteBuffer);
         }
     }
@@ -110,30 +134,42 @@ public class CipherSubscriber implements Subscriber<ByteBuffer> {
         // If content length is null, we should include everything in the cipher because the stream is essentially
         // unbounded.
         if (contentLength == null) {
+            System.out.println("[CipherSubscriber] Content length is null, reading entire buffer: " + byteBuffer.remaining());
             return byteBuffer.remaining();
         }
 
         long amountReadSoFar = contentRead.getAndAdd(byteBuffer.remaining());
         long amountRemaining = Math.max(0, contentLength - amountReadSoFar);
+        System.out.println("[CipherSubscriber] Buffer read calculation - read: " + amountReadSoFar + ", remaining: " + amountRemaining + ", buffer size: " + byteBuffer.remaining());
 
         if (amountRemaining > byteBuffer.remaining()) {
+            System.out.println("[CipherSubscriber] Reading entire buffer: " + byteBuffer.remaining());
             return byteBuffer.remaining();
         } else {
+            System.out.println("[CipherSubscriber] Reading partial buffer: " + amountRemaining);
             return Math.toIntExact(amountRemaining);
         }
     }
 
     @Override
     public void onError(Throwable t) {
+        System.out.println("[CipherSubscriber] Error occurred: " + t.getMessage());
         wrappedSubscriber.onError(t);
     }
 
     @Override
     public void onComplete() {
+        System.out.println("[CipherSubscriber] onComplete called");
+        wrappedSubscriber.onComplete();
+    }
+
+    public void finalBytes() {
+        System.out.println("[CipherSubscriber] finalBytes called, isLastPart: " + isLastPart + ", onCompleteCalled: " + onCompleteCalled);
         // onComplete can be signalled to CipherSubscriber multiple times,
         // but additional calls should be deduped to avoid calling onNext multiple times
         // and raising exceptions.
         if (onCompleteCalled) {
+            System.out.println("[CipherSubscriber] finalBytes already called, returning");
             return;
         }
         onCompleteCalled = true;
@@ -142,10 +178,11 @@ public class CipherSubscriber implements Subscriber<ByteBuffer> {
         // doFinal requires that all parts have been processed to compute the tag,
         // so the tag will only be computed when the last part is processed.
         if (!isLastPart) {
+            System.out.println("[CipherSubscriber] Not last part, sending output buffer of size: " + (outputBuffer != null ? outputBuffer.length : 0));
             // First, propagate the bytes that were in outputBuffer downstream.
             wrappedSubscriber.onNext(ByteBuffer.wrap(outputBuffer));
             // Then, propagate the onComplete signal downstream.
-            wrappedSubscriber.onComplete();
+//            wrappedSubscriber.onComplete();
             return;
         }
 
@@ -153,14 +190,17 @@ public class CipherSubscriber implements Subscriber<ByteBuffer> {
         // The result of doFinal MUST be included with the bytes that were in outputBuffer in the final onNext call.
         byte[] finalBytes = null;
         try {
+            System.out.println("[CipherSubscriber] Calling cipher.doFinal()");
             finalBytes = cipher.doFinal();
+            System.out.println("[CipherSubscriber] doFinal produced " + (finalBytes != null ? finalBytes.length : 0) + " bytes");
         } catch (final GeneralSecurityException exception) {
             // Even if doFinal fails, downstream still expects to receive the bytes that were in outputBuffer
+            System.out.println("[CipherSubscriber] Security exception during doFinal: " + exception.getMessage());
             wrappedSubscriber.onNext(ByteBuffer.wrap(outputBuffer));
             // Forward error, else the wrapped subscriber waits indefinitely
             wrappedSubscriber.onError(exception);
             // Even though doFinal failed, propagate the onComplete signal downstream
-            wrappedSubscriber.onComplete();
+//            wrappedSubscriber.onComplete();
             throw new S3EncryptionClientSecurityException(exception.getMessage(), exception);
         }
 
@@ -169,19 +209,24 @@ public class CipherSubscriber implements Subscriber<ByteBuffer> {
         // This single onNext call must contain both the bytes from outputBuffer and the tag.
         byte[] combinedBytes;
         if (outputBuffer != null && outputBuffer.length > 0 && finalBytes != null && finalBytes.length > 0) {
+            System.out.println("[CipherSubscriber] Combining outputBuffer (" + outputBuffer.length + " bytes) with finalBytes (" + finalBytes.length + " bytes)");
             combinedBytes = new byte[outputBuffer.length + finalBytes.length];
             System.arraycopy(outputBuffer, 0, combinedBytes, 0, outputBuffer.length);
             System.arraycopy(finalBytes, 0, combinedBytes, outputBuffer.length, finalBytes.length);
         } else if (outputBuffer != null && outputBuffer.length > 0) {
+            System.out.println("[CipherSubscriber] Using only outputBuffer (" + outputBuffer.length + " bytes)");
             combinedBytes = outputBuffer;
         } else if (finalBytes != null && finalBytes.length > 0) {
+            System.out.println("[CipherSubscriber] Using only finalBytes (" + finalBytes.length + " bytes)");
             combinedBytes = finalBytes;
         } else {
+            System.out.println("[CipherSubscriber] No bytes to send");
             combinedBytes = new byte[0];
         }
 
+        System.out.println("[CipherSubscriber] Sending combined bytes to wrapped subscriber of length " + combinedBytes.length);
         wrappedSubscriber.onNext(ByteBuffer.wrap(combinedBytes));
-        wrappedSubscriber.onComplete();
+//        wrappedSubscriber.onComplete();
     }
 
 }

--- a/src/main/java/software/amazon/encryption/s3/internal/CipherSubscriber.java
+++ b/src/main/java/software/amazon/encryption/s3/internal/CipherSubscriber.java
@@ -11,7 +11,6 @@ import software.amazon.encryption.s3.materials.CryptographicMaterials;
 import javax.crypto.Cipher;
 import java.nio.ByteBuffer;
 import java.security.GeneralSecurityException;
-import java.util.Arrays;
 import java.util.concurrent.atomic.AtomicLong;
 
 public class CipherSubscriber implements Subscriber<ByteBuffer> {
@@ -20,15 +19,16 @@ public class CipherSubscriber implements Subscriber<ByteBuffer> {
     private Cipher cipher;
     private final Long contentLength;
     private boolean isLastPart;
+    private boolean finalized;
 
     private byte[] outputBuffer;
 
     CipherSubscriber(Subscriber<? super ByteBuffer> wrappedSubscriber, Long contentLength, CryptographicMaterials materials, byte[] iv, boolean isLastPart) {
-        System.out.println("[CipherSubscriber] Constructor called with contentLength: " + contentLength + ", isLastPart: " + isLastPart);
         this.wrappedSubscriber = wrappedSubscriber;
         this.contentLength = contentLength;
         cipher = materials.getCipher(iv);
         this.isLastPart = isLastPart;
+        this.finalized = false;
     }
 
     CipherSubscriber(Subscriber<? super ByteBuffer> wrappedSubscriber, Long contentLength, CryptographicMaterials materials, byte[] iv) {
@@ -39,17 +39,16 @@ public class CipherSubscriber implements Subscriber<ByteBuffer> {
     @Override
     public void onSubscribe(Subscription s) {
         System.out.println("[CipherSubscriber] onSubscribe called with subscription: " + s);
-
         wrappedSubscriber.onSubscribe(new Subscription() {
             @Override
             public void request(long n) {
-                System.out.println("[CipherSubscriber] Request called for " + n + " items");
+                System.out.println("[CipherSubscriber] New request received for " + n + " items");
                 s.request(n);
             }
 
             @Override
             public void cancel() {
-                System.out.println("[CipherSubscriber] Cancel called");
+                System.out.println("[CipherSubscriber] Subscription cancelled");
                 s.cancel();
             }
         });
@@ -58,6 +57,7 @@ public class CipherSubscriber implements Subscriber<ByteBuffer> {
     @Override
     public void onNext(ByteBuffer byteBuffer) {
         System.out.println("[CipherSubscriber] onNext called with buffer size: " + byteBuffer.remaining());
+        System.out.println("[CipherSubscriber] isLastPart: " + isLastPart);
         int amountToReadFromByteBuffer = getAmountToReadFromByteBuffer(byteBuffer);
         System.out.println("[CipherSubscriber] amountToReadFromByteBuffer: " + amountToReadFromByteBuffer);
 
@@ -69,50 +69,53 @@ public class CipherSubscriber implements Subscriber<ByteBuffer> {
             outputBuffer = cipher.update(buf, 0, amountToReadFromByteBuffer);
             System.out.println("[CipherSubscriber] Cipher update produced output buffer of length: " + (outputBuffer != null ? outputBuffer.length : 0));
 
-            boolean atEnd = isLastPart && contentRead.get() >= contentLength - 16;
-            System.out.println("[CipherSubscriber] atEnd: " + atEnd + " (isLastPart: " + isLastPart + ", contentRead: " + contentRead.get() + ", contentLength: " + contentLength + ")");
-
-            if (atEnd) {
-                System.out.println("[CipherSubscriber] Processing final bytes");
-                // The final bytes must be sent with the final onNext call, not during the onComplete call.
-                byte[] finalBytes;
-                try {
-                    finalBytes = cipher.doFinal();
-                    System.out.println("[CipherSubscriber] Cipher doFinal produced " + finalBytes.length + " bytes");
-                } catch (final GeneralSecurityException exception) {
-                    System.out.println("[CipherSubscriber] Error during doFinal: " + exception.getMessage());
-                    wrappedSubscriber.onError(exception);
-                    throw new S3EncryptionClientSecurityException(exception.getMessage(), exception);
-                }
-
-                // Combine outputBuffer and finalBytes if both exist
-                byte[] combinedBuffer;
-                if (outputBuffer != null && outputBuffer.length > 0) {
-                    System.out.println("[CipherSubscriber] Combining outputBuffer (" + outputBuffer.length + " bytes) with finalBytes (" + finalBytes.length + " bytes)");
-                    combinedBuffer = new byte[outputBuffer.length + finalBytes.length];
-                    System.arraycopy(outputBuffer, 0, combinedBuffer, 0, outputBuffer.length);
-                    System.arraycopy(finalBytes, 0, combinedBuffer, outputBuffer.length, finalBytes.length);
-                    System.out.println("[CipherSubscriber] Combined buffer total length: " + combinedBuffer.length);
-                } else {
-                    System.out.println("[CipherSubscriber] Using only finalBytes (" + finalBytes.length + " bytes)");
-                    combinedBuffer = finalBytes;
-                }
-                
-                System.out.println("[CipherSubscriber] Sending combined buffer to wrapped subscriber");
-                wrappedSubscriber.onNext(ByteBuffer.wrap(combinedBuffer));
-                return;
-            } else if (outputBuffer == null || outputBuffer.length == 0) {
-                System.out.println("[CipherSubscriber] No bytes from cipher update, sending empty buffer");
+            if (outputBuffer == null || outputBuffer.length == 0) {
+                System.out.println("[CipherSubscriber] No output from cipher update");
                 // No bytes provided from upstream; to avoid blocking, send an empty buffer to the wrapped subscriber.
-                return;
+                wrappedSubscriber.onNext(ByteBuffer.allocate(0));
             } else {
-                System.out.println("[CipherSubscriber] Sending " + outputBuffer.length + " bytes to wrapped subscriber");
-                // Not at end; send content so far
-                wrappedSubscriber.onNext(ByteBuffer.wrap(outputBuffer));
+                boolean atEnd = isLastPart && contentRead.get() + amountToReadFromByteBuffer >= contentLength;
+                System.out.println("[CipherSubscriber] atEnd: " + atEnd + " (contentRead: " + contentRead.get() + ", contentLength: " + contentLength + ")");
+
+                if (atEnd) {
+                    System.out.println("[CipherSubscriber] Processing final bytes");
+                    // If all content has been read, send the final bytes in this onNext call.
+                    // The final bytes must be sent with the final onNext call, not during the onComplete call.
+                    byte[] finalBytes;
+                    try {
+                        finalBytes = cipher.doFinal();
+                        finalized = true;
+                        System.out.println("[CipherSubscriber] Cipher doFinal produced " + finalBytes.length + " bytes");
+                    } catch (final GeneralSecurityException exception) {
+                        System.out.println("[CipherSubscriber] Error during doFinal: " + exception.getMessage());
+                        wrappedSubscriber.onError(exception);
+                        throw new S3EncryptionClientSecurityException(exception.getMessage(), exception);
+                    }
+
+                    // Combine outputBuffer and finalBytes if both exist
+                    byte[] combinedBuffer;
+                    if (outputBuffer != null && outputBuffer.length > 0) {
+                        System.out.println("[CipherSubscriber] Combining outputBuffer (" + outputBuffer.length + " bytes) with finalBytes (" + finalBytes.length + " bytes)");
+                        combinedBuffer = new byte[outputBuffer.length + finalBytes.length];
+                        System.arraycopy(outputBuffer, 0, combinedBuffer, 0, outputBuffer.length);
+                        System.arraycopy(finalBytes, 0, combinedBuffer, outputBuffer.length, finalBytes.length);
+                        System.out.println("[CipherSubscriber] Combined buffer total length: " + combinedBuffer.length);
+                    } else {
+                        System.out.println("[CipherSubscriber] Using only finalBytes (" + finalBytes.length + " bytes)");
+                        combinedBuffer = finalBytes;
+                    }
+                    System.out.println("[CipherSubscriber] Sending combined buffer to wrapped subscriber");
+                    wrappedSubscriber.onNext(ByteBuffer.wrap(combinedBuffer));
+                } else {
+                    System.out.println("[CipherSubscriber] Sending " + outputBuffer.length + " bytes to wrapped subscriber");
+                    // Not at end; send content so far
+                    wrappedSubscriber.onNext(ByteBuffer.wrap(outputBuffer));
+                }
             }
         } else {
-            System.out.println("[CipherSubscriber] No bytes to read from input buffer");
-            return;
+            System.out.println("[CipherSubscriber] No bytes to read from input buffer, forwarding original buffer");
+            // Do nothing
+            wrappedSubscriber.onNext(byteBuffer);
         }
     }
 
@@ -148,7 +151,23 @@ public class CipherSubscriber implements Subscriber<ByteBuffer> {
 
     @Override
     public void onComplete() {
-        System.out.println("[CipherSubscriber] onComplete called");
+        if (!isLastPart) {
+            // If this isn't the last part, skip doFinal, we aren't done
+            wrappedSubscriber.onComplete();
+            return;
+        } if (finalized) {
+            wrappedSubscriber.onComplete();
+            return;
+        }
+        try {
+            outputBuffer = cipher.doFinal();
+            // Send the final bytes to the wrapped subscriber
+            wrappedSubscriber.onNext(ByteBuffer.wrap(outputBuffer));
+        } catch (final GeneralSecurityException exception) {
+            // Forward error, else the wrapped subscriber waits indefinitely
+            wrappedSubscriber.onError(exception);
+            throw new S3EncryptionClientSecurityException(exception.getMessage(), exception);
+        }
         wrappedSubscriber.onComplete();
     }
 

--- a/src/main/java/software/amazon/encryption/s3/internal/CipherSubscriber.java
+++ b/src/main/java/software/amazon/encryption/s3/internal/CipherSubscriber.java
@@ -47,17 +47,14 @@ public class CipherSubscriber implements Subscriber<ByteBuffer> {
 
     @Override
     public void onSubscribe(Subscription s) {
-        //System.out.println("[CipherSubscriber] onSubscribe called with subscription: " + s);
         wrappedSubscriber.onSubscribe(new Subscription() {
             @Override
             public void request(long n) {
-                //System.out.println("[CipherSubscriber] Request received for " + n + " items");
                 s.request(n);
             }
 
             @Override
             public void cancel() {
-                //System.out.println("[CipherSubscriber] Subscription cancelled");
                 s.cancel();
             }
         });
@@ -65,15 +62,11 @@ public class CipherSubscriber implements Subscriber<ByteBuffer> {
 
     @Override
     public void onNext(ByteBuffer byteBuffer) {
-        //System.out.println("[CipherSubscriber] onNext called with buffer size: " + byteBuffer.remaining() + ", contentRead: " + contentRead.get() + ", contentLength: " + contentLength);
         int amountToReadFromByteBuffer = getAmountToReadFromByteBuffer(byteBuffer);
-        //System.out.println("[CipherSubscriber] Amount to read from buffer: " + amountToReadFromByteBuffer);
 
         if (amountToReadFromByteBuffer > 0) {
             byte[] buf = BinaryUtils.copyBytesFrom(byteBuffer, amountToReadFromByteBuffer);
-            //System.out.println("[CipherSubscriber] Copied " + buf.length + " bytes from input buffer");
             outputBuffer = cipher.update(buf, 0, amountToReadFromByteBuffer);
-            //System.out.println("[CipherSubscriber] Cipher update produced " + (outputBuffer != null ? outputBuffer.length : 0) + " bytes");
 
             if (outputBuffer == null || outputBuffer.length == 0) {
                 // The underlying data is too short to fill in the block cipher.
@@ -82,13 +75,11 @@ public class CipherSubscriber implements Subscriber<ByteBuffer> {
                 // null OR length == 0.
                 if (contentRead.get() + tagLength >= contentLength) {
                     // All content has been read, so complete to get the final bytes
-                    //System.out.println("[CipherSubscriber] All content read (" + contentRead.get() + " bytes), proceeding to finalBytes");
                     finalBytes();
                     return;
                 }
                 // Otherwise, wait for more bytes. To avoid blocking,
                 // send an empty buffer to the wrapped subscriber.
-                //System.out.println("[CipherSubscriber] Sending empty buffer to wrapped subscriber");
                 wrappedSubscriber.onNext(ByteBuffer.allocate(0));
             } else {
                 // Check if stream has read all expected content.
@@ -108,23 +99,19 @@ public class CipherSubscriber implements Subscriber<ByteBuffer> {
                 // including the result of cipher.doFinal(), if applicable.
                 // Calling `wrappedSubscriber.onNext` more than once for `request(1)` 
                 // violates the Reactive Streams specification and can cause exceptions downstream.
-                //System.out.println("[CipherSubscriber] Checking content read threshold: contentRead=" + contentRead.get() + ", tagLength=" + tagLength + ", contentLength=" + contentLength);
                 if (contentRead.get() + tagLength >= contentLength) {
                     // All content has been read; complete the stream.
                     // (Signalling onComplete from here is Reactive Streams-spec compliant;
                     // this class is allowed to call onComplete, even if upstream has not yet signaled onComplete.)
-                    //System.out.println("[CipherSubscriber] Content read threshold (" + contentRead.get() + ") reached, proceeding to finalBytes");
                     finalBytes();
                 } else {
                     // Needs to read more data, so send the data downstream,
                     // expecting that downstream will continue to request more data.
-                    //System.out.println("[CipherSubscriber] Sending " + outputBuffer.length + " bytes to wrapped subscriber");
                     wrappedSubscriber.onNext(ByteBuffer.wrap(outputBuffer));
                 }
             }
         } else {
             // Do nothing
-            //System.out.println("[CipherSubscriber] No data to process, forwarding buffer directly");
             wrappedSubscriber.onNext(byteBuffer);
         }
     }
@@ -133,37 +120,30 @@ public class CipherSubscriber implements Subscriber<ByteBuffer> {
         // If content length is null, we should include everything in the cipher because the stream is essentially
         // unbounded.
         if (contentLength == null) {
-            //System.out.println("[CipherSubscriber] Content length is null, reading entire buffer: " + byteBuffer.remaining());
             return byteBuffer.remaining();
         }
 
         long amountReadSoFar = contentRead.getAndAdd(byteBuffer.remaining());
         long amountRemaining = Math.max(0, contentLength - amountReadSoFar);
-        //System.out.println("[CipherSubscriber] Buffer read calculation - read: " + amountReadSoFar + ", remaining: " + amountRemaining + ", buffer size: " + byteBuffer.remaining());
 
         if (amountRemaining > byteBuffer.remaining()) {
-            //System.out.println("[CipherSubscriber] Reading entire buffer: " + byteBuffer.remaining());
             return byteBuffer.remaining();
         } else {
-            //System.out.println("[CipherSubscriber] Reading partial buffer: " + amountRemaining);
             return Math.toIntExact(amountRemaining);
         }
     }
 
     @Override
     public void onError(Throwable t) {
-        //System.out.println("[CipherSubscriber] Error occurred: " + t.getMessage());
         wrappedSubscriber.onError(t);
     }
 
     @Override
     public void onComplete() {
-        //System.out.println("[CipherSubscriber] onComplete called");
+        // In rare cases, e.g. when the last part of a low-level MPU has 0 length,
+        // onComplete will be called before onNext is called once.
         if (contentRead.get() < contentLength) {
-            //System.out.println("[CipherSubscriber] onComplete called prematurely! The content read is " + contentRead.get() + " but the contentLength is " + contentLength);
-            //System.out.println("try just calling finalBytes() straight up");
             finalBytes();
-            //System.out.println("now let it complete");
         }
         wrappedSubscriber.onComplete();
     }
@@ -172,9 +152,7 @@ public class CipherSubscriber implements Subscriber<ByteBuffer> {
         // If this isn't the last part, skip doFinal and just send outputBuffer downstream.
         // doFinal requires that all parts have been processed to compute the tag,
         // so the tag will only be computed when the last part is processed.
-        //System.out.println("[CipherSubscriber] finalBytes called, isLastPart: " + isLastPart);
         if (!isLastPart) {
-            //System.out.println("[CipherSubscriber] Not last part, sending output buffer of size: " + (outputBuffer != null ? outputBuffer.length : 0));
             wrappedSubscriber.onNext(ByteBuffer.wrap(outputBuffer));
             return;
         }
@@ -183,11 +161,9 @@ public class CipherSubscriber implements Subscriber<ByteBuffer> {
         // The result of doFinal MUST be included with the bytes that were in outputBuffer in the final onNext call.
         byte[] finalBytes;
         try {
-            //System.out.println("[CipherSubscriber] Calling cipher.doFinal()");
             finalBytes = cipher.doFinal();
         } catch (final GeneralSecurityException exception) {
             // Even if doFinal fails, downstream still expects to receive the bytes that were in outputBuffer
-            //System.out.println("[CipherSubscriber] Security exception during doFinal: " + exception.getMessage());
             wrappedSubscriber.onNext(ByteBuffer.wrap(outputBuffer));
             // Forward error, else the wrapped subscriber waits indefinitely
             wrappedSubscriber.onError(exception);
@@ -199,22 +175,17 @@ public class CipherSubscriber implements Subscriber<ByteBuffer> {
         // This single onNext call must contain both the bytes from outputBuffer and the tag.
         byte[] combinedBytes;
         if (outputBuffer != null && outputBuffer.length > 0 && finalBytes != null && finalBytes.length > 0) {
-            //System.out.println("[CipherSubscriber] Combining outputBuffer (" + outputBuffer.length + " bytes) with finalBytes (" + finalBytes.length + " bytes)");
             combinedBytes = new byte[outputBuffer.length + finalBytes.length];
             System.arraycopy(outputBuffer, 0, combinedBytes, 0, outputBuffer.length);
             System.arraycopy(finalBytes, 0, combinedBytes, outputBuffer.length, finalBytes.length);
         } else if (outputBuffer != null && outputBuffer.length > 0) {
-            //System.out.println("[CipherSubscriber] Using only outputBuffer (" + outputBuffer.length + " bytes)");
             combinedBytes = outputBuffer;
         } else if (finalBytes != null && finalBytes.length > 0) {
-            //System.out.println("[CipherSubscriber] Using only finalBytes (" + finalBytes.length + " bytes)");
             combinedBytes = finalBytes;
         } else {
-            //System.out.println("[CipherSubscriber] No bytes to send");
             combinedBytes = new byte[0];
         }
 
-        //System.out.println("[CipherSubscriber] Sending combined bytes to wrapped subscriber of length " + combinedBytes.length);
         wrappedSubscriber.onNext(ByteBuffer.wrap(combinedBytes));
     }
 

--- a/src/main/java/software/amazon/encryption/s3/internal/CipherSubscriber.java
+++ b/src/main/java/software/amazon/encryption/s3/internal/CipherSubscriber.java
@@ -73,8 +73,8 @@ public class CipherSubscriber implements Subscriber<ByteBuffer> {
             } else {
                 // Once all content has been read, call onComplete.
                 // This class can identify when all content has been read because the amount of data read so far
-                // plus the tag length will equal the content length.
-                if (contentRead.get() + tagLength == contentLength) {
+                // plus the tag length exceeds the content length.
+                if (contentRead.get() + tagLength >= contentLength) {
                     // All content has been read, so complete the stream.
                     // The next onNext call MUST include all bytes, including the result of cipher.doFinal().
                     // Sending any additional onNext calls violates the Reactive Streams specification

--- a/src/main/java/software/amazon/encryption/s3/internal/CipherSubscriber.java
+++ b/src/main/java/software/amazon/encryption/s3/internal/CipherSubscriber.java
@@ -38,17 +38,14 @@ public class CipherSubscriber implements Subscriber<ByteBuffer> {
 
     @Override
     public void onSubscribe(Subscription s) {
-        System.out.println("[CipherSubscriber] onSubscribe called with subscription: " + s);
         wrappedSubscriber.onSubscribe(new Subscription() {
             @Override
             public void request(long n) {
-                System.out.println("[CipherSubscriber] New request received for " + n + " items");
                 s.request(n);
             }
 
             @Override
             public void cancel() {
-                System.out.println("[CipherSubscriber] Subscription cancelled");
                 s.cancel();
             }
         });
@@ -56,38 +53,26 @@ public class CipherSubscriber implements Subscriber<ByteBuffer> {
 
     @Override
     public void onNext(ByteBuffer byteBuffer) {
-        System.out.println("[CipherSubscriber] onNext called with buffer size: " + byteBuffer.remaining());
-        System.out.println("[CipherSubscriber] isLastPart: " + isLastPart);
         int amountToReadFromByteBuffer = getAmountToReadFromByteBuffer(byteBuffer);
-        System.out.println("[CipherSubscriber] amountToReadFromByteBuffer: " + amountToReadFromByteBuffer);
 
         if (amountToReadFromByteBuffer > 0) {
-            System.out.println("[CipherSubscriber] Processing chunk of size: " + amountToReadFromByteBuffer);
             byte[] buf = BinaryUtils.copyBytesFrom(byteBuffer, amountToReadFromByteBuffer);
-            System.out.println("[CipherSubscriber] Copied " + buf.length + " bytes from input buffer");
-            
             outputBuffer = cipher.update(buf, 0, amountToReadFromByteBuffer);
-            System.out.println("[CipherSubscriber] Cipher update produced output buffer of length: " + (outputBuffer != null ? outputBuffer.length : 0));
 
             if (outputBuffer == null || outputBuffer.length == 0) {
-                System.out.println("[CipherSubscriber] No output from cipher update");
                 // No bytes provided from upstream; to avoid blocking, send an empty buffer to the wrapped subscriber.
                 wrappedSubscriber.onNext(ByteBuffer.allocate(0));
             } else {
                 boolean atEnd = isLastPart && contentRead.get() + amountToReadFromByteBuffer >= contentLength;
-                System.out.println("[CipherSubscriber] atEnd: " + atEnd + " (contentRead: " + contentRead.get() + ", contentLength: " + contentLength + ")");
 
                 if (atEnd) {
-                    System.out.println("[CipherSubscriber] Processing final bytes");
                     // If all content has been read, send the final bytes in this onNext call.
                     // The final bytes must be sent with the final onNext call, not during the onComplete call.
                     byte[] finalBytes;
                     try {
                         finalBytes = cipher.doFinal();
                         finalized = true;
-                        System.out.println("[CipherSubscriber] Cipher doFinal produced " + finalBytes.length + " bytes");
                     } catch (final GeneralSecurityException exception) {
-                        System.out.println("[CipherSubscriber] Error during doFinal: " + exception.getMessage());
                         wrappedSubscriber.onError(exception);
                         throw new S3EncryptionClientSecurityException(exception.getMessage(), exception);
                     }
@@ -95,57 +80,43 @@ public class CipherSubscriber implements Subscriber<ByteBuffer> {
                     // Combine outputBuffer and finalBytes if both exist
                     byte[] combinedBuffer;
                     if (outputBuffer != null && outputBuffer.length > 0) {
-                        System.out.println("[CipherSubscriber] Combining outputBuffer (" + outputBuffer.length + " bytes) with finalBytes (" + finalBytes.length + " bytes)");
                         combinedBuffer = new byte[outputBuffer.length + finalBytes.length];
                         System.arraycopy(outputBuffer, 0, combinedBuffer, 0, outputBuffer.length);
                         System.arraycopy(finalBytes, 0, combinedBuffer, outputBuffer.length, finalBytes.length);
-                        System.out.println("[CipherSubscriber] Combined buffer total length: " + combinedBuffer.length);
                     } else {
-                        System.out.println("[CipherSubscriber] Using only finalBytes (" + finalBytes.length + " bytes)");
                         combinedBuffer = finalBytes;
                     }
-                    System.out.println("[CipherSubscriber] Sending combined buffer to wrapped subscriber");
                     wrappedSubscriber.onNext(ByteBuffer.wrap(combinedBuffer));
                 } else {
-                    System.out.println("[CipherSubscriber] Sending " + outputBuffer.length + " bytes to wrapped subscriber");
                     // Not at end; send content so far
                     wrappedSubscriber.onNext(ByteBuffer.wrap(outputBuffer));
                 }
             }
         } else {
-            System.out.println("[CipherSubscriber] No bytes to read from input buffer, forwarding original buffer");
             // Do nothing
             wrappedSubscriber.onNext(byteBuffer);
         }
     }
 
     private int getAmountToReadFromByteBuffer(ByteBuffer byteBuffer) {
-        System.out.println("[CipherSubscriber] getAmountToReadFromByteBuffer called with buffer remaining: " + byteBuffer.remaining());
-        System.out.println("[CipherSubscriber] Current contentRead: " + contentRead.get() + ", contentLength: " + contentLength);
-
         // If content length is null, we should include everything in the cipher because the stream is essentially
         // unbounded.
         if (contentLength == null) {
-            System.out.println("[CipherSubscriber] No content length specified, reading entire buffer: " + byteBuffer.remaining());
             return byteBuffer.remaining();
         }
 
         long amountReadSoFar = contentRead.getAndAdd(byteBuffer.remaining());
         long amountRemaining = Math.max(0, contentLength - amountReadSoFar);
-        System.out.println("[CipherSubscriber] amountReadSoFar: " + amountReadSoFar + ", amountRemaining: " + amountRemaining);
 
         if (amountRemaining > byteBuffer.remaining()) {
-            System.out.println("[CipherSubscriber] More remaining than buffer size, reading entire buffer: " + byteBuffer.remaining());
             return byteBuffer.remaining();
         } else {
-            System.out.println("[CipherSubscriber] Reading partial buffer: " + amountRemaining);
             return Math.toIntExact(amountRemaining);
         }
     }
 
     @Override
     public void onError(Throwable t) {
-        System.out.println("[CipherSubscriber] onError called: " + t.getMessage());
         wrappedSubscriber.onError(t);
     }
 

--- a/src/main/java/software/amazon/encryption/s3/internal/CipherSubscriber.java
+++ b/src/main/java/software/amazon/encryption/s3/internal/CipherSubscriber.java
@@ -66,6 +66,7 @@ public class CipherSubscriber implements Subscriber<ByteBuffer> {
                 } else {
                     // Done, wait for upstream to signal onComplete
                     System.out.println("[CipherSubscriber] All content read (contentRead: " + contentRead.get() + ", contentLength: " + contentLength + "), waiting for onComplete");
+                    this.onComplete();
                 }
             }
         } else {

--- a/src/main/resources/log4j.properties
+++ b/src/main/resources/log4j.properties
@@ -1,4 +1,0 @@
-log4j.properties:
-log4j.rootLogger=ERROR,stdout
-log4j.appender.stdout=org.apache.log4j.ConsoleAppender
-log4j.appender.stdout.layout=org.apache.log4j.PatternLayout

--- a/src/main/resources/log4j.properties
+++ b/src/main/resources/log4j.properties
@@ -1,0 +1,4 @@
+log4j.properties:
+log4j.rootLogger=ERROR,stdout
+log4j.appender.stdout=org.apache.log4j.ConsoleAppender
+log4j.appender.stdout.layout=org.apache.log4j.PatternLayout

--- a/src/test/java/software/amazon/encryption/s3/S3AsyncEncryptionClientTest.java
+++ b/src/test/java/software/amazon/encryption/s3/S3AsyncEncryptionClientTest.java
@@ -729,6 +729,8 @@ public class S3AsyncEncryptionClientTest {
      * Test which artificially limits the size of buffers using {@link TinyBufferAsyncRequestBody}.
      * This tests edge cases where network conditions result in buffers with length shorter than
      * the cipher's block size.
+     * Note that TinyAsyncRequestBody is not fully spec-compliant, and will cause IllegalStateExceptions
+     * to be logged when debug logging is enabled.
      * @throws IOException
      */
     @Test

--- a/src/test/java/software/amazon/encryption/s3/S3EncryptionClientRangedGetCompatibilityTest.java
+++ b/src/test/java/software/amazon/encryption/s3/S3EncryptionClientRangedGetCompatibilityTest.java
@@ -264,6 +264,7 @@ public class S3EncryptionClientRangedGetCompatibilityTest {
         assertEquals("klmnopqrst0", output);
 
         // Valid start index within input and end index out of range, returns object from start index to End of Stream
+        // This causes a spurious NPE to be logged when debug logging is enabled.
         objectResponse = v3Client.getObject(builder -> builder
                 .bucket(BUCKET)
                 .range("bytes=190-300")
@@ -288,6 +289,7 @@ public class S3EncryptionClientRangedGetCompatibilityTest {
         assertEquals(input, output);
 
         // Invalid range starting index and ending index greater than object length but within Cipher Block size, returns empty object
+        // This causes a spurious NPE to be logged when debug logging is enabled.
         objectResponse = v3Client.getObject(builder -> builder
                 .bucket(BUCKET)
                 .range("bytes=216-217")

--- a/src/test/java/software/amazon/encryption/s3/utils/TinyBufferAsyncRequestBody.java
+++ b/src/test/java/software/amazon/encryption/s3/utils/TinyBufferAsyncRequestBody.java
@@ -10,6 +10,9 @@ import java.util.Optional;
  * AsyncRequestBody which wraps another AsyncRequestBody with a {@link TinyBufferSubscriber}.
  * This is useful for testing poor network conditions where buffers may not be larger than
  * the cipher's block size.
+ * DO NOT USE THIS IN PRODUCTION. In addition to degraded performance,
+ * it will cause IllegalStateExceptions in the base Subscriber as it does not comply
+ * with the Reactive Streaming spec.
  */
 public class TinyBufferAsyncRequestBody implements AsyncRequestBody {
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

# Check any applicable:
- [ ] Were any files moved? Moving files changes their URL, which breaks all hyperlinks to the files.
