### PR TITLE
fix: disable low-level Multipart Upload in Async client

### DIFF
--- a/src/main/java/software/amazon/encryption/s3/S3AsyncEncryptionClient.java
+++ b/src/main/java/software/amazon/encryption/s3/S3AsyncEncryptionClient.java
@@ -20,6 +20,10 @@ import software.amazon.awssdk.services.s3.S3AsyncClient;
 import software.amazon.awssdk.services.s3.S3AsyncClientBuilder;
 import software.amazon.awssdk.services.s3.S3Configuration;
 import software.amazon.awssdk.services.s3.internal.crt.S3CrtAsyncClient;
+import software.amazon.awssdk.services.s3.model.CompleteMultipartUploadRequest;
+import software.amazon.awssdk.services.s3.model.CompleteMultipartUploadResponse;
+import software.amazon.awssdk.services.s3.model.CreateMultipartUploadRequest;
+import software.amazon.awssdk.services.s3.model.CreateMultipartUploadResponse;
 import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
 import software.amazon.awssdk.services.s3.model.DeleteObjectResponse;
 import software.amazon.awssdk.services.s3.model.DeleteObjectsRequest;
@@ -30,6 +34,8 @@ import software.amazon.awssdk.services.s3.model.ObjectIdentifier;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 import software.amazon.awssdk.services.s3.model.PutObjectResponse;
 import software.amazon.awssdk.services.s3.model.S3Request;
+import software.amazon.awssdk.services.s3.model.UploadPartRequest;
+import software.amazon.awssdk.services.s3.model.UploadPartResponse;
 import software.amazon.awssdk.services.s3.multipart.MultipartConfiguration;
 import software.amazon.encryption.s3.internal.GetEncryptedObjectPipeline;
 import software.amazon.encryption.s3.internal.InstructionFileConfig;
@@ -254,6 +260,24 @@ public class S3AsyncEncryptionClient extends DelegatingS3AsyncClient {
                 .overrideConfiguration(API_NAME_INTERCEPTOR)
                 .delete(builder -> builder.objects(objectsToDelete))
                 .build());
+    }
+
+    @Override
+    public CompletableFuture<CreateMultipartUploadResponse> createMultipartUpload(CreateMultipartUploadRequest createMultipartUploadRequest) {
+        throw new UnsupportedOperationException("The S3 Async Encryption Client does not support low-level multipart uploads. " +
+                "Please use Multipart PutObject or the default (synchronous) client to use this API.");
+    }
+
+    @Override
+    public CompletableFuture<UploadPartResponse> uploadPart(UploadPartRequest uploadPartRequest, AsyncRequestBody asyncRequestBody) {
+        throw new UnsupportedOperationException("The S3 Async Encryption Client does not support low-level multipart uploads. " +
+                "Please use Multipart PutObject or the default (synchronous) client to use this API.");
+    }
+
+    @Override
+    public CompletableFuture<CompleteMultipartUploadResponse> completeMultipartUpload(CompleteMultipartUploadRequest completeMultipartUploadRequest) {
+        throw new UnsupportedOperationException("The S3 Async Encryption Client does not support low-level multipart uploads. " +
+                "Please use Multipart PutObject or the default (synchronous) client to use this API.");
     }
 
     /**

--- a/src/test/java/software/amazon/encryption/s3/S3AsyncEncryptionClientTest.java
+++ b/src/test/java/software/amazon/encryption/s3/S3AsyncEncryptionClientTest.java
@@ -910,16 +910,46 @@ public class S3AsyncEncryptionClientTest {
     }
 
     @Test
-    public void S3AsyncClientBuilderForbidsMultipartEnabled() throws IOException {
+    public void s3AsyncClientBuilderForbidsMultipartEnabled() {
         assertThrows(
             UnsupportedOperationException.class,
             () -> S3AsyncEncryptionClient.builder().multipartEnabled(Boolean.TRUE));
     }
 
     @Test
-    public void S3AsyncClientBuilderForbidsMultipartConfiguration() throws IOException {
+    public void s3AsyncClientBuilderForbidsMultipartConfiguration() {
         assertThrows(
             UnsupportedOperationException.class,
             () -> S3AsyncEncryptionClient.builder().multipartConfiguration(MultipartConfiguration.builder().build()));
+    }
+
+    @Test
+    public void s3AsyncClientForbidsCreateMultipartUpload() {
+        S3AsyncClient s3AsyncClient = S3AsyncEncryptionClient.builder()
+                .kmsKeyId("fails")
+                .build();
+
+        assertThrows(UnsupportedOperationException.class, () -> s3AsyncClient.createMultipartUpload(builder -> builder.bucket(BUCKET).key("expected-fail").build()).join());
+        s3AsyncClient.close();
+    }
+
+    @Test
+    public void s3AsyncClientForbidsUploadPart() {
+        S3AsyncClient s3AsyncClient = S3AsyncEncryptionClient.builder()
+                .kmsKeyId("fails")
+                .build();
+
+        assertThrows(UnsupportedOperationException.class, () -> s3AsyncClient.uploadPart(builder -> builder.uploadId("fail").build(), AsyncRequestBody.fromString("fail")).join());
+        s3AsyncClient.close();
+    }
+
+    @Test
+    public void s3AsyncClientForbidsCompleteMultipartUpload() {
+        S3AsyncClient s3AsyncClient = S3AsyncEncryptionClient.builder()
+                .kmsKeyId("fails")
+                .build();
+
+        assertThrows(UnsupportedOperationException.class, () -> s3AsyncClient.completeMultipartUpload(builder -> builder.uploadId("fail").build()).join());
+        s3AsyncClient.close();
     }
 }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

The async client does not support "low-level" multipart uploads via CreateMPU/UploadPart/CompleteMPU. However, these APIs are accessible through the delegate client, which is misleading. This change overrides the unsupported operations and throws exceptions accordingly. 

This MAY break some customers, however, it is safer that way as otherwise objects are uploaded in plaintext. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

# Check any applicable:
- [ ] Were any files moved? Moving files changes their URL, which breaks all hyperlinks to the files.
