### PR TITLE
fix: semantic-release to temporary use dependency  

### DIFF
--- a/codebuild/release/version.yml
+++ b/codebuild/release/version.yml
@@ -30,4 +30,4 @@ phases:
   build:
     commands:
       # semantic-release uses config stored in ~/.releaserc
-      - npx semantic-release --branches $BRANCH --no-ci
+      - npx --package=conventional-changelog-conventionalcommits --package=@semantic-release/git --package=@semantic-release/exec --package=@semantic-release/changelog semantic-release --branches $BRANCH --no-ci


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

# Check any applicable:
- [ ] Were any files moved? Moving files changes their URL, which breaks all hyperlinks to the files.
