### PR TITLE
fix: scm url

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@
   </developers>
 
   <scm>
-    <url>https://github.com/aws/amazon-s3-encryption-client.git</url>
+    <url>https://github.com/aws/amazon-s3-encryption-client-java.git</url>
   </scm>
 
   <properties>


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* Resubmitted copy of https://github.com/aws/amazon-s3-encryption-client-java/pull/469 so CI can run. 


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

# Check any applicable:
- [ ] Were any files moved? Moving files changes their URL, which breaks all hyperlinks to the files.
