### PR TITLE
chore(release): skip openjdk11 during release validation

### DIFF
--- a/codebuild/release/release.yml
+++ b/codebuild/release/release.yml
@@ -22,19 +22,9 @@ batch:
         JAVA_NUMERIC_VERSION: 8
       image: aws/codebuild/standard:3.0
 
-  - identifier: validate_staging_release_openjdk11
-    depend-on:
-      - validate_staging_release_openjdk8
-    buildspec: codebuild/release/validate-staging.yml
-    env:
-      variables:
-        JAVA_ENV_VERSION: openjdk11
-        JAVA_NUMERIC_VERSION: 11
-      image: aws/codebuild/standard:3.0
-
   - identifier: validate_staging_release_corretto8
     depend-on:
-      - validate_staging_release_openjdk11
+      - validate_staging_release_openjdk8
     buildspec: codebuild/release/validate-staging.yml
     env:
       variables:


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* Codebuild openjdk11 is having some problem with its certificate. Skip openjdk11 during release validation. This should be OK because we still test on corretto11 which is deriied from openjdk11, and we don't do anything platform-specific in general anyway. 


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

# Check any applicable:
- [ ] Were any files moved? Moving files changes their URL, which breaks all hyperlinks to the files.
