### PR TITLE
ci: add Java 21 to CI matrix

### DIFF
--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       fail-fast: false # TODO: Set to true once CI is stable
       matrix:
-        version: [ 8, 11, 17 ]
+        version: [ 8, 11, 17, 21 ]
         distribution: [ corretto, temurin ] # TODO: Add OpenJDK
     uses: ./.github/workflows/build.yml
     secrets: inherit


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Add Java 21 to the CI build matrix. Previously tested on Java 8, 11, and 17. This aligns with what was done for DBESDK in aws/aws-database-encryption-sdk-dynamodb#2159.

*Squash/merge commit message, if applicable:*

ci: add Java 21 to CI matrix

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.