### PR TITLE
fix: throw S3EC error on GCM key/IV reuse 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -82,7 +82,7 @@
       <groupId>software.amazon.awssdk.crt</groupId>
       <artifactId>aws-crt</artifactId>
       <optional>true</optional>
-      <version>0.41.0</version>
+      <version>0.45.1</version>
     </dependency>
 
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -82,7 +82,7 @@
       <groupId>software.amazon.awssdk.crt</groupId>
       <artifactId>aws-crt</artifactId>
       <optional>true</optional>
-      <version>0.37.0</version>
+      <version>0.41.0</version>
     </dependency>
 
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -56,7 +56,7 @@
       <dependency>
         <groupId>software.amazon.awssdk</groupId>
         <artifactId>bom</artifactId>
-        <version>2.31.14</version>
+        <version>2.43.0</version>
         <optional>true</optional>
         <type>pom</type>
         <scope>import</scope>
@@ -68,13 +68,13 @@
     <dependency>
       <groupId>software.amazon.awssdk</groupId>
       <artifactId>s3</artifactId>
-      <version>2.31.14</version>
+      <version>2.43.0</version>
     </dependency>
 
     <dependency>
       <groupId>software.amazon.awssdk</groupId>
       <artifactId>kms</artifactId>
-      <version>2.31.14</version>
+      <version>2.43.0</version>
     </dependency>
 
     <!-- Used when enableMultipartPutObject is configured -->
@@ -169,7 +169,7 @@
     <dependency>
       <groupId>software.amazon.awssdk</groupId>
       <artifactId>sts</artifactId>
-      <version>2.31.14</version>
+      <version>2.43.0</version>
       <optional>true</optional>
       <scope>test</scope>
     </dependency>

--- a/src/main/java/software/amazon/encryption/s3/internal/PutEncryptedObjectPipeline.java
+++ b/src/main/java/software/amazon/encryption/s3/internal/PutEncryptedObjectPipeline.java
@@ -84,7 +84,7 @@ public class PutEncryptedObjectPipeline {
                 .overrideConfiguration(API_NAME_INTERCEPTOR)
                 .contentLength(encryptedContent.getCiphertextLength())
                 .build();
-        return _s3AsyncClient.putObject(encryptedPutRequest, encryptedContent.getAsyncCiphertext());
+        return _s3AsyncClient.putObject(encryptedPutRequest, new NoRetriesAsyncRequestBody(encryptedContent.getAsyncCiphertext()));
     }
 
     public static class Builder {

--- a/src/test/java/software/amazon/encryption/s3/S3AsyncEncryptionClientTest.java
+++ b/src/test/java/software/amazon/encryption/s3/S3AsyncEncryptionClientTest.java
@@ -365,11 +365,12 @@ public class S3AsyncEncryptionClientTest {
 
         try {
             PutObjectRequest request = PutObjectRequest.builder().bucket(BUCKET).key(objectKey).build();
-            S3EncryptionClientException ex = assertThrows(S3EncryptionClientException.class, () ->
+            CompletionException ex = assertThrows(CompletionException.class, () ->
                     s3Client.putObject(request, AsyncRequestBody.fromBytes("test".getBytes())).join());
             // Cross-region redirect causes the SDK to re-subscribe to the request body.
             // NoRetriesAsyncRequestBody blocks this to prevent GCM cipher key/IV reuse.
-            assertTrue(ex.getMessage().contains("Re-subscription is not supported"));
+            assertTrue(ex.getCause() instanceof S3EncryptionClientException);
+            assertTrue(ex.getCause().getMessage().contains("Re-subscription is not supported"));
         } finally {
             s3Client.close();
         }

--- a/src/test/java/software/amazon/encryption/s3/S3AsyncEncryptionClientTest.java
+++ b/src/test/java/software/amazon/encryption/s3/S3AsyncEncryptionClientTest.java
@@ -46,6 +46,7 @@ import software.amazon.awssdk.services.s3.model.StorageClass;
 import software.amazon.awssdk.services.s3.multipart.MultipartConfiguration;
 import software.amazon.encryption.s3.algorithms.AlgorithmSuite;
 import software.amazon.encryption.s3.internal.InstructionFileConfig;
+import software.amazon.encryption.s3.materials.AesKeyring;
 import software.amazon.encryption.s3.materials.KmsKeyring;
 import software.amazon.encryption.s3.utils.BoundedInputStream;
 import software.amazon.encryption.s3.utils.S3EncryptionClientTestResources;
@@ -53,6 +54,7 @@ import software.amazon.encryption.s3.utils.TinyBufferAsyncRequestBody;
 
 import javax.crypto.KeyGenerator;
 import javax.crypto.SecretKey;
+import javax.crypto.spec.SecretKeySpec;
 import java.io.IOException;
 import java.io.InputStream;
 import java.security.NoSuchAlgorithmException;
@@ -344,6 +346,30 @@ public class S3AsyncEncryptionClientTest {
             fail("expected exception");
         } catch (NotFoundException e) {
             assertTrue(e.getMessage().contains("Invalid arn"));
+        } finally {
+            s3Client.close();
+        }
+    }
+
+    @RetryingTest(3)
+    public void roundTripWithCrossRegionAccessEnabled() {
+        final String objectKey = appendTestSuffix("roundTripWithCrossRegionAccessEnabled-async-s3ec");
+        SecretKeySpec aesKey = new SecretKeySpec(new byte[32], "AES");
+        AesKeyring keyRing = AesKeyring.builder().wrappingKey(aesKey).build();
+
+        S3AsyncClient s3Client = S3AsyncEncryptionClient.builderV4()
+                .region(Region.EU_CENTRAL_1)
+                .crossRegionAccessEnabled(true)
+                .keyring(keyRing)
+                .build();
+
+        try {
+            PutObjectRequest request = PutObjectRequest.builder().bucket(BUCKET).key(objectKey).build();
+            S3EncryptionClientException ex = assertThrows(S3EncryptionClientException.class, () ->
+                    s3Client.putObject(request, AsyncRequestBody.fromBytes("test".getBytes())).join());
+            // Cross-region redirect causes the SDK to re-subscribe to the request body.
+            // NoRetriesAsyncRequestBody blocks this to prevent GCM cipher key/IV reuse.
+            assertTrue(ex.getMessage().contains("Re-subscription is not supported"));
         } finally {
             s3Client.close();
         }

--- a/src/test/java/software/amazon/encryption/s3/S3EncryptionClientTest.java
+++ b/src/test/java/software/amazon/encryption/s3/S3EncryptionClientTest.java
@@ -985,7 +985,7 @@ public class S3EncryptionClientTest {
                     s3.putObject(request, RequestBody.fromBytes("test".getBytes())));
             // Cross-region redirect causes the SDK to re-subscribe to the request body.
             // S3EC blocks this to prevent GCM cipher key/IV reuse.
-            assertTrue(ex.getMessage().contains("Re-subscription is not supported"));
+            assertTrue(ex.getCause().getMessage().contains("Re-subscription is not supported"));
         } finally {
             s3.close();
         }

--- a/src/test/java/software/amazon/encryption/s3/S3EncryptionClientTest.java
+++ b/src/test/java/software/amazon/encryption/s3/S3EncryptionClientTest.java
@@ -984,7 +984,7 @@ public class S3EncryptionClientTest {
             S3EncryptionClientException ex = assertThrows(S3EncryptionClientException.class, () ->
                     s3.putObject(request, RequestBody.fromBytes("test".getBytes())));
             // Cross-region redirect causes the SDK to re-subscribe to the request body.
-            // NoRetriesAsyncRequestBody blocks this to prevent GCM cipher key/IV reuse.
+            // S3EC blocks this to prevent GCM cipher key/IV reuse.
             assertTrue(ex.getMessage().contains("Re-subscription is not supported"));
         } finally {
             s3.close();

--- a/src/test/java/software/amazon/encryption/s3/S3EncryptionClientTest.java
+++ b/src/test/java/software/amazon/encryption/s3/S3EncryptionClientTest.java
@@ -17,6 +17,7 @@ import com.amazonaws.services.s3.model.KMSEncryptionMaterials;
 import com.amazonaws.services.s3.model.StaticEncryptionMaterialsProvider;
 import org.bouncycastle.jce.provider.BouncyCastleProvider;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 import org.junitpioneer.jupiter.RetryingTest;
 import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
 import software.amazon.awssdk.auth.credentials.AwsSessionCredentials;
@@ -966,7 +967,7 @@ public class S3EncryptionClientTest {
         }
     }
 
-    @RetryingTest(3)
+    @Test
     public void crossRegionRoundTrip() {
         final String objectKey = appendTestSuffix("cross-region-test");
         SecretKeySpec aesKey = new SecretKeySpec(new byte[32], "AES");
@@ -980,14 +981,12 @@ public class S3EncryptionClientTest {
 
         try {
             PutObjectRequest request = PutObjectRequest.builder().bucket(BUCKET).key(objectKey).build();
-            s3.putObject(request, RequestBody.fromBytes("test".getBytes()));
-            ResponseBytes<GetObjectResponse> response = s3.getObjectAsBytes(builder -> builder
-                    .bucket(BUCKET)
-                    .key(objectKey)
-                    .build());
-            assertEquals("test", response.asUtf8String());
+            S3EncryptionClientException ex = assertThrows(S3EncryptionClientException.class, () ->
+                    s3.putObject(request, RequestBody.fromBytes("test".getBytes())));
+            // Cross-region redirect causes the SDK to re-subscribe to the request body.
+            // NoRetriesAsyncRequestBody blocks this to prevent GCM cipher key/IV reuse.
+            assertTrue(ex.getMessage().contains("Re-subscription is not supported"));
         } finally {
-            deleteObject(BUCKET, objectKey, s3);
             s3.close();
         }
     }

--- a/src/test/java/software/amazon/encryption/s3/S3EncryptionClientTest.java
+++ b/src/test/java/software/amazon/encryption/s3/S3EncryptionClientTest.java
@@ -17,7 +17,6 @@ import com.amazonaws.services.s3.model.KMSEncryptionMaterials;
 import com.amazonaws.services.s3.model.StaticEncryptionMaterialsProvider;
 import org.bouncycastle.jce.provider.BouncyCastleProvider;
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Test;
 import org.junitpioneer.jupiter.RetryingTest;
 import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
 import software.amazon.awssdk.auth.credentials.AwsSessionCredentials;

--- a/src/test/java/software/amazon/encryption/s3/S3EncryptionClientTest.java
+++ b/src/test/java/software/amazon/encryption/s3/S3EncryptionClientTest.java
@@ -967,9 +967,9 @@ public class S3EncryptionClientTest {
         }
     }
 
-    @Test
-    public void crossRegionRoundTrip() {
-        final String objectKey = appendTestSuffix("cross-region-test");
+    @RetryingTest(3)
+    public void roundTripWithCrossRegionAccessEnabled() {
+        final String objectKey = appendTestSuffix("roundTripWithCrossRegionAccessEnabled-sync-s3ec");
         SecretKeySpec aesKey = new SecretKeySpec(new byte[32], "AES");
         AesKeyring keyRing = AesKeyring.builder().wrappingKey(aesKey).build();
 

--- a/src/test/java/software/amazon/encryption/s3/S3EncryptionClientTest.java
+++ b/src/test/java/software/amazon/encryption/s3/S3EncryptionClientTest.java
@@ -42,6 +42,7 @@ import software.amazon.awssdk.services.s3.model.S3Exception;
 import software.amazon.encryption.s3.algorithms.AlgorithmSuite;
 import software.amazon.encryption.s3.internal.InstructionFileConfig;
 import software.amazon.encryption.s3.internal.MetadataKeyConstants;
+import software.amazon.encryption.s3.materials.AesKeyring;
 import software.amazon.encryption.s3.materials.CryptographicMaterialsManager;
 import software.amazon.encryption.s3.materials.DefaultCryptoMaterialsManager;
 import software.amazon.encryption.s3.materials.KmsKeyring;
@@ -52,6 +53,7 @@ import software.amazon.encryption.s3.utils.S3EncryptionClientTestResources;
 
 import javax.crypto.KeyGenerator;
 import javax.crypto.SecretKey;
+import javax.crypto.spec.SecretKeySpec;
 import java.security.KeyPair;
 import java.security.KeyPairGenerator;
 import java.security.NoSuchAlgorithmException;
@@ -961,6 +963,32 @@ public class S3EncryptionClientTest {
         } finally {
             // Cleanup
             s3Client.close();
+        }
+    }
+
+    @RetryingTest(3)
+    public void crossRegionRoundTrip() {
+        final String objectKey = appendTestSuffix("cross-region-test");
+        SecretKeySpec aesKey = new SecretKeySpec(new byte[32], "AES");
+        AesKeyring keyRing = AesKeyring.builder().wrappingKey(aesKey).build();
+
+        S3Client s3 = S3EncryptionClient.builderV4()
+                .region(Region.EU_CENTRAL_1)
+                .crossRegionAccessEnabled(true)
+                .keyring(keyRing)
+                .build();
+
+        try {
+            PutObjectRequest request = PutObjectRequest.builder().bucket(BUCKET).key(objectKey).build();
+            s3.putObject(request, RequestBody.fromBytes("test".getBytes()));
+            ResponseBytes<GetObjectResponse> response = s3.getObjectAsBytes(builder -> builder
+                    .bucket(BUCKET)
+                    .key(objectKey)
+                    .build());
+            assertEquals("test", response.asUtf8String());
+        } finally {
+            deleteObject(BUCKET, objectKey, s3);
+            s3.close();
         }
     }
 


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/amazon-s3-encryption-client-java/issues/510

*Description of changes:*

> This is a little bending change as expected error type is getting change but I don't think consumers of S3EC will be depending on the JCE error.

When `crossRegionAccessEnabled(true)` triggers a redirect, the SDK re-subscribes to the request body, which would reuse the same AES-GCM key/IV. This change wraps the encrypted request body in `NoRetriesAsyncRequestBody` to proactively block re-subscription with a clear `S3EncryptionClientException` instead of low-level error message thrown by JCE provider.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

# Check any applicable:
- [ ] Were any files moved? Moving files changes their URL, which breaks all hyperlinks to the files.
